### PR TITLE
fix: add pod yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@
 npm install screwdriver-executor-k8s-vm
 ```
 
+### Initialization
+The class provides a couple options that are configurable in the instantiation of this Executor
+
+| Parameter        | Type  | Default    | Description |
+| :-------------   | :---- | :----------| :-----------|
+| config        | Object | | Configuration Object |
+| config.kubernetes | Object | {} | Kubernetes configuration Object |
+| config.kubernetes.token | String | '' | The JWT token used for authenticating to the Kubernetes cluster. (If not passed in, we will read from `/var/run/secrets/kubernetes.io/serviceaccount/token`.) |
+| config.kubernetes.host | String | 'kubernetes.defaults' | The hostname for the Kubernetes cluster (kubernetes) |
+| config.ecosystem | Object | | Screwdriver Ecosystem (ui, api, store, etc.) |
+| config.launchVersion | String | 'stable' | Launcher container version to use (stable) |
+| config.prefix | String | '' |Prefix to container names ("") |
+| config.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |
+| config.baseImage | String | '' | Base image used to start the VM |
+
+
+### Methods
+
+For more information on `start`, `stop`, and `stats` please see the [executor-base-class].
+
 ## Testing
 
 ```bash
@@ -25,7 +45,7 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [license-image]: https://img.shields.io/npm/l/screwdriver-executor-k8s-vm.svg
 [issues-image]: https://img.shields.io/github/issues/screwdriver-cd/executor-k8s-vm.svg
 [issues-url]: https://github.com/screwdriver-cd/executor-k8s-vm/issues
-[status-image]: https://cd.screwdriver.cd/pipelines/pipelineid/badge
-[status-url]: https://cd.screwdriver.cd/pipelines/pipelineid
+[status-image]: https://cd.screwdriver.cd/pipelines/235/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/235
 [daviddm-image]: https://david-dm.org/screwdriver-cd/executor-k8s-vm.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/executor-k8s-vm

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -4,52 +4,62 @@ metadata:
   name: "{{build_id_with_prefix}}"
   labels:
     sdbuild: "{{build_id_with_prefix}}"
-    app: screwdriver
+    app: screwdriver-vm
     tier: builds
   annotations:
-    pod.alpha.kubernetes.io/init-containers: '[
-      {
-        "name": "launcher",
-        "image": "screwdrivercd/launcher:{{launcher_version}}",
-        "command": ["/bin/sh", "-c", "cp -a /opt/sd/* /opt/launcher"],
-        "volumeMounts": [
-          {
-            "name": "screwdriver",
-            "mountPath": "/opt/launcher"
-          }
-        ]
-      }
-    ]'
+   pod.alpha.kubernetes.io/init-containers: '[
+     {
+       "name": "launcher",
+       "image": "screwdrivercd/launcher:{{launcher_version}}",
+       "command": ["/bin/sh", "-c", "cp -a /opt/sd/* /opt/launcher"],
+       "volumeMounts": [
+         {
+           "name": "sdlauncher",
+           "mountPath": "/opt/launcher"
+         }
+       ]
+     }
+  ]'
 spec:
-  serviceAccount: {{service_account}}
   restartPolicy: Never
   containers:
-  - name: build
-    image: {{container}}
+  - name: vm-launcher
+    image: {{base_image}}
+    imagePullPolicy: Always
+    securityContext:
+      privileged: true
     resources:
       limits:
         memory: 2Gi
-    command:
-    - "/opt/sd/tini"
-    - "--"
-    - "/bin/sh"
-    - "-c"
-    # Run the launcher and logservice in the background
-    # Wait for both background jobs to complete
-    - |
-      /opt/sd/launch --api-uri {{api_uri}} --emitter /opt/sd/emitter {{build_id}} &
-      /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{store_uri}} --build {{build_id}} &
-      wait $(jobs -p)
+    command: ["/sd/hyper-runner.sh"]
+    args: [
+         "--container", "{{container}}",
+         "--api_uri", "{{api_uri}}",
+         "--store_uri", "{{store_uri}}",
+         "--build_id", "{{build_id}}",
+         "--id_with_prefix", "{{build_id_with_prefix}}",
+         "--build_token", "{{token}}"
+          ]
     volumeMounts:
-    - mountPath: /opt/sd
-      name: screwdriver
-    - mountPath: /sd
-      name: workspace
-    env:
-    - name: SD_TOKEN
-      value: "{{token}}"
+    - mountPath: /var/run
+      name: hyper-socket
+    - mountPath: /var/sd-workspaces
+      name: sd-workspaces
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/bash", "-c", "sleep 2; # This sleep is to wait for hyper to gracefully exit normally on successful build
+                    rm -rf /var/sd-workspaces/{{build_id_with_prefix}};
+                    hyperctl rm builder-{{build_id_with_prefix}}"]
   volumes:
-    - name: screwdriver
-      emptyDir: {}
-    - name: workspace
-      emptyDir: {}
+    - name: hyper-socket
+      hostPath:
+        path: /var/run
+
+    - name: sd-workspaces
+      hostPath:
+        path: /opt/screwdriver
+
+    - name: sdlauncher
+      hostPath:
+        path: /opt/screwdriver/{{build_id_with_prefix}}/sdlauncher


### PR DESCRIPTION
## Context
We want to allow builds to run inside a VM in Kubernetes. 
This pod yaml will pass arguments into `/sd/hyper-runner.sh`. This script is available in the  `{{base_image}}`, and is expected to start the VMs
`baseImage` is configurable by cluster manager via an environment variable: https://github.com/screwdriver-cd/screwdriver/pull/625/files

## Objective
To allow build to run inside a VM in Kubernetes

## References
Related to https://github.com/screwdriver-cd/screwdriver/issues/597
