### PR TITLE
fix: remove comments

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -48,7 +48,7 @@ spec:
     lifecycle:
       preStop:
         exec:
-          command: ["/bin/bash", "-c", "sleep 2; # This sleep is to wait for hyper to gracefully exit normally on successful build
+          command: ["/bin/bash", "-c", "sleep 2;
                     rm -rf /var/sd-workspaces/{{build_id_with_prefix}};
                     hyperctl rm builder-{{build_id_with_prefix}}"]
   volumes:


### PR DESCRIPTION
The comment actually comment the rest of the commands, so it doesn't do the cleanup