### PR TITLE
fix: checks pod status after creation

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{build_id_with_prefix}}"
+  name: "{{pod_name}}"
   labels:
     sdbuild: "{{build_id_with_prefix}}"
     app: screwdriver-vm

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Executor = require('screwdriver-executor-base');
 const path = require('path');
 const Fusebox = require('circuit-fuses');
 const requestretry = require('requestretry');
+const randomstring = require('randomstring');
 const tinytim = require('tinytim');
 const yaml = require('js-yaml');
 const fs = require('fs');
@@ -64,7 +65,9 @@ class K8sVMExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
+        const random = randomstring.generate(5);
         const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
+            pod_name: `${this.prefix}${config.buildId}-${random}`,
             build_id_with_prefix: `${this.prefix}${config.buildId}`,
             build_id: config.buildId,
             container: config.container,
@@ -74,7 +77,6 @@ class K8sVMExecutor extends Executor {
             launcher_version: this.launchVersion,
             base_image: this.baseImage
         });
-
         const options = {
             uri: this.podsUrl,
             method: 'POST',

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dependencies": {
         "circuit-fuses": "^2.1.0",
         "js-yaml": "^3.6.1",
-        "request": "^2.72.0",
+        "requestretry": "^1.12.2",
         "screwdriver-executor-base": "^5.2.0",
         "tinytim": "^0.1.1"
     }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dependencies": {
         "circuit-fuses": "^2.1.0",
         "js-yaml": "^3.6.1",
+        "randomstring": "^1.1.5",
         "requestretry": "^1.12.2",
         "screwdriver-executor-base": "^5.2.0",
         "tinytim": "^0.1.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,7 +42,6 @@ describe('index', function () {
 
     beforeEach(() => {
         requestRetryMock = sinon.stub();
-        requestRetryMock = sinon.stub();
 
         fsMock = {
             readFileSync: sinon.stub(),
@@ -56,7 +55,6 @@ describe('index', function () {
         fsMock.existsSync.returns(true);
 
         mockery.registerMock('fs', fsMock);
-        mockery.registerMock('request', requestRetryMock);
         mockery.registerMock('requestretry', requestRetryMock);
 
         /* eslint-disable global-require */


### PR DESCRIPTION
Currently, pod creation returns `201`, but afterward, it might fail at initcontainer, or after that. However, the error doesn't get caught because because `_start` already returns. So the status of the build stays as `QUEUED` forever even though the pod failed. 

This PR:
- checks the pod status after it's created. If the status is `failed` or `unknown`, it will throw error. The queue worker will catch this, retry, and report back to API that this build failed (https://github.com/screwdriver-cd/queue-worker/blob/master/index.js#L90-L91). 
- adds random string to pod name so that the queue can recreate the pod (currently unable to recreate pod if name is the same)

Resources:
https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#read-status-69
