### PR TITLE
feat: spread pods across nodes

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -21,6 +21,16 @@ metadata:
      }
   ]'
 spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - screwdriver-vm
+        topologyKey: kubernetes.io/hostname
   restartPolicy: Never
   containers:
   - name: vm-launcher


### PR DESCRIPTION
We have observed that a lot of pods got assigned to the same node around the same time. To better allocate resources, this PR will add `podAntiAffinity` to spread pods across nodes.

This blob means whenever it is possible, do not schedule the current build pod to a node that has a build pod running already.

All build pod has label `app: screwdriver-vm` and `kubernetes.io/hostname` is the hostname for node.

Reference: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetesiohostname

@chestery Can you help review it?