### PR TITLE
fix: switch to use semantic-release template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
switch to use semantic-release template

Builds are failing due to latest semantic-release requires node:8
https://cd.screwdriver.cd/pipelines/235/builds/12623