### PR TITLE
fix(631): Add HIGH resource values for cpu and ram

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -43,6 +43,8 @@ spec:
         memory: 2Gi
     command: ["/sd/hyper-runner.sh"]
     args: [
+         "--cpu", "{{cpu}}",
+         "--memory", "{{memory}}",
          "--container", "{{container}}",
          "--api_uri", "{{api_uri}}",
          "--store_uri", "{{store_uri}}",

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -45,8 +45,8 @@ spec:
         memory: 2Gi
     command: ["/sd/hyper-runner.sh"]
     args: [
-         "--cpu", "{{cpu}}",
-         "--memory", "{{memory}}",
+         "--cpu", {{cpu}},
+         "--memory", {{memory}},
          "--container", "{{container}}",
          "--api_uri", "{{api_uri}}",
          "--store_uri", "{{store_uri}}",

--- a/index.js
+++ b/index.js
@@ -68,6 +68,18 @@ class K8sVMExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
+        // Default to 2 vcpu and 2GB memory
+        let CPU = 2;
+        let MEMORY = 2048;
+        const resourceType = hoek.reach(config, 'annotations', {
+            default: {}
+        })[ANNOTATION_RESOURCE_TYPE];
+
+        if (resourceType === 'HIGH') {
+            CPU = 6;
+            MEMORY = 12288; // 12GB
+        }
+
         const random = randomstring.generate({
             length: 5,
             charset: 'alphanumeric',
@@ -94,17 +106,6 @@ class K8sVMExecutor extends Executor {
             strictSSL: false,
             json: true
         };
-        // Default to 2 vcpu and 2GB memory
-        let CPU = 2;
-        let MEMORY = 2048;
-        const resourceType = hoek.reach(config, 'annotations', {
-            default: {}
-        })[ANNOTATION_RESOURCE_TYPE];
-
-        if (resourceType === 'HIGH') {
-            CPU = 6;
-            MEMORY = 12288; // 12GB
-        }
 
         return this.breaker.runCommand(options)
             .then((resp) => {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "pretest": "eslint .",
-        "test": "jenkins-mocha --recursive",
+        "test": "jenkins-mocha --recursive --timeout 5000",
         "semantic-release": "semantic-release pre && npm publish && semantic-release post"
     },
     "engines": {
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "circuit-fuses": "^2.1.0",
+        "hoek": "^5.0.2",
         "js-yaml": "^3.6.1",
         "randomstring": "^1.1.5",
         "requestretry": "^1.12.2",


### PR DESCRIPTION
## Context

It would be nice if people could choose their CPU and RAM settings for jobs.

## Objective

This PR sets resources:
- default - 2 vcpu, 2GB memory
- `HIGH` - 6 vcpu, 12GB memory

 The resources can be configured by setting job-level annotation `beta.screwdriver.cd/resource: 'HIGH'`.

## Related links

Original issue: https://github.com/screwdriver-cd/screwdriver/issues/631
- CPU: https://github.com/screwdriver-cd/screwdriver/issues/758
- RAM: https://github.com/screwdriver-cd/screwdriver/issues/759
