### PR TITLE
fix: affinity and pod name

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -24,13 +24,15 @@ spec:
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app
-            operator: In
-            values:
-            - screwdriver-vm
-        topologyKey: kubernetes.io/hostname
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - screwdriver-vm
   restartPolicy: Never
   containers:
   - name: vm-launcher

--- a/index.js
+++ b/index.js
@@ -65,7 +65,11 @@ class K8sVMExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
-        const random = randomstring.generate(5);
+        const random = randomstring.generate({
+            length: 5,
+            charset: 'alphanumeric',
+            capitalization: 'lowercase'
+        });
         const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
             pod_name: `${this.prefix}${config.buildId}-${random}`,
             build_id_with_prefix: `${this.prefix}${config.buildId}`,


### PR DESCRIPTION
Worker is broken right now. 2 issues:
- affinity needs `weight`, and a couple other keywords
- podname cannot be uppercase