### PR TITLE
fix: retry when status is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "circuit-fuses": "^2.1.0",
+        "hoek": "^5.0.2",
         "js-yaml": "^3.6.1",
         "randomstring": "^1.1.5",
         "requestretry": "^1.12.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -304,8 +304,8 @@ describe('index', function () {
                     message: 'cannot get pod status'
                 }
             };
-            const returnMessage =
-                `Failed to get pod status: ${JSON.stringify(returnResponse.body)}`;
+            const returnMessage = `Failed to get pod status:
+                        ${JSON.stringify(returnResponse.body, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(
                 null, returnResponse, returnResponse.body);
@@ -331,8 +331,8 @@ describe('index', function () {
                     }
                 }
             };
-            const returnMessage =
-                `Failed to create pod. Pod status is: ${JSON.stringify(returnResponse.body)}`;
+            const returnMessage = `Failed to create pod. Pod status is:
+                        ${JSON.stringify(returnResponse.body.status, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(
                 null, returnResponse, returnResponse.body);


### PR DESCRIPTION
Previously, body might not have `status.phase` so it actually just runs once and fails. 