### PR TITLE
fix: Expecting quotes in arguments

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -45,8 +45,8 @@ spec:
         memory: 2Gi
     command: ["/sd/hyper-runner.sh"]
     args: [
-         "--cpu", {{cpu}},
-         "--memory", {{memory}},
+         "--cpu", "{{cpu}}",
+         "--memory", "{{memory}}",
          "--container", "{{container}}",
          "--api_uri", "{{api_uri}}",
          "--store_uri", "{{store_uri}}",


### PR DESCRIPTION
Getting failures in the queue worker log:
```
error: err in start job:  Error: Failed to create pod: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod in version \"v1\" cannot be handled as a Pod: [pos 997]: json: expect char '\"' but got char '6'","reason":"BadRequest","code":400}
```