### PR TITLE
fix: allow setting CPU and RAM separately

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const randomstring = require('randomstring');
 const requestretry = require('requestretry');
 const tinytim = require('tinytim');
 const yaml = require('js-yaml');
-const ANNOTATION_RESOURCE_TYPE = 'beta.screwdriver.cd/resource'; // Key in annotations object that maps to a resource type (HIGH or LOW)
+const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
+const RAM_RESOURCE = 'beta.screwdriver.cd/ram';
 
 class K8sVMExecutor extends Executor {
     /**
@@ -68,18 +69,10 @@ class K8sVMExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
-        // Default to 2 vcpu and 2GB memory
-        let CPU = 2;
-        let MEMORY = 2048;
-        const resourceType = hoek.reach(config, 'annotations', {
-            default: {}
-        })[ANNOTATION_RESOURCE_TYPE];
-
-        if (resourceType === 'HIGH') {
-            CPU = 6;
-            MEMORY = 12288; // 12GB
-        }
-
+        const cpuConfig = hoek.reach(config, 'annotations', { default: {} })[CPU_RESOURCE];
+        const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
+        const CPU = (cpuConfig === 'HIGH') ? 6 : 2;
+        const MEMORY = (ramConfig === 'HIGH') ? 12288 : 2048;   // 12GB or 2GB
         const random = randomstring.generate({
             length: 5,
             charset: 'alphanumeric',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "screwdriver-executor-k8s-vm",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "Kubernetes VM Executor plugin for Screwdriver",
     "main": "index.js",
     "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -280,13 +280,32 @@ describe('index', () => {
             })
         );
 
-        it('sets the CPU and memory appropriately when resource is set to HIGH', () => {
-            postConfig.body.metadata.cpu = 6;
+        it('sets the memory appropriately when ram is set to HIGH', () => {
+            postConfig.body.metadata.cpu = 2;
             postConfig.body.metadata.memory = 12288;
 
             return executor.start({
                 annotations: {
-                    'beta.screwdriver.cd/resource': 'HIGH'
+                    'beta.screwdriver.cd/ram': 'HIGH'
+                },
+                buildId: testBuildId,
+                container: testContainer,
+                token: testToken,
+                apiUri: testApiUri
+            }).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall,
+                    sinon.match(getConfig));
+            });
+        });
+
+        it('sets the CPU appropriately when cpu is set to HIGH', () => {
+            postConfig.body.metadata.cpu = 6;
+            postConfig.body.metadata.memory = 2048;
+
+            return executor.start({
+                annotations: {
+                    'beta.screwdriver.cd/cpu': 'HIGH'
                 },
                 buildId: testBuildId,
                 container: testContainer,


### PR DESCRIPTION
Allow setting them separately
Related: 
https://github.com/screwdriver-cd/screwdriver/issues/758
https://github.com/screwdriver-cd/screwdriver/issues/759