### PR TITLE
fix: make high/low cpu/memory configurable by the cluster

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,18 +18,23 @@ class K8sVMExecutor extends Executor {
     /**
      * Constructor
      * @method constructor
-     * @param  {Object} options                                      Configuration options
-     * @param  {Object} options.ecosystem                            Screwdriver Ecosystem
-     * @param  {Object} options.ecosystem.api                        Routable URI to Screwdriver API
-     * @param  {Object} options.ecosystem.store                      Routable URI to Screwdriver Store
-     * @param  {Object} options.kubernetes                           Kubernetes configuration
-     * @param  {String} [options.kubernetes.token]                   API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
-     * @param  {String} [options.kubernetes.host=kubernetes.default] Kubernetes hostname
-     * @param  {String} [options.kubernetes.jobsNamespace=default]   Pods namespace for Screwdriver Jobs
-     * @param  {String} [options.kubernetes.baseImage]               Base image for the pod
-     * @param  {String} [options.launchVersion=stable]               Launcher container version to use
-     * @param  {String} [options.prefix='']                          Prefix for job name
-     * @param  {String} [options.fusebox]                            Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
+     * @param  {Object} options                                       Configuration options
+     * @param  {Object} options.ecosystem                             Screwdriver Ecosystem
+     * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
+     * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
+     * @param  {Object} options.kubernetes                            Kubernetes configuration
+     * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
+     * @param  {String} [options.kubernetes.host=kubernetes.default]  Kubernetes hostname
+     * @param  {String} [options.kubernetes.jobsNamespace=default]    Pods namespace for Screwdriver Jobs
+     * @param  {String} [options.kubernetes.baseImage]                Base image for the pod
+     * @param  {String} [options.kubernetes.resources.cpu.high=6]     Value for HIGH CPU (in cores)
+     * @param  {Number} [options.kubernetes.resources.cpu.low=2]      Value for LOW CPU (in cores)
+     * @param  {Number} [options.kubernetes.resources.memory.high=12] Value for HIGH memory (in GB)
+     * @param  {Number} [options.kubernetes.resources.memory.low=2]   Value for LOW memory (in GB)
+     * @param  {Number} [options.kubernetes.jobsNamespace=default]    Pods namespace for Screwdriver Jobs
+     * @param  {String} [options.launchVersion=stable]                Launcher container version to use
+     * @param  {String} [options.prefix='']                           Prefix for job name
+     * @param  {String} [options.fusebox]                             Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
      */
     constructor(options = {}) {
         super();
@@ -51,6 +56,10 @@ class K8sVMExecutor extends Executor {
         this.baseImage = this.kubernetes.baseImage;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
+        this.highCpu = hoek.reach(options, 'kubernetes.resources.cpu.high', { default: 6 });
+        this.lowCpu = hoek.reach(options, 'kubernetes.resources.cpu.low', { default: 2 });
+        this.highMemory = hoek.reach(options, 'kubernetes.resources.memory.high', { default: 12 });
+        this.lowMemory = hoek.reach(options, 'kubernetes.resources.memory.low', { default: 2 });
         this.podRetryStrategy = (err, response, body) => {
             const status = hoek.reach(body, 'status.phase');
 
@@ -71,8 +80,8 @@ class K8sVMExecutor extends Executor {
     _start(config) {
         const cpuConfig = hoek.reach(config, 'annotations', { default: {} })[CPU_RESOURCE];
         const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
-        const CPU = (cpuConfig === 'HIGH') ? 6 : 2;
-        const MEMORY = (ramConfig === 'HIGH') ? 12288 : 2048;   // 12GB or 2GB
+        const CPU = (cpuConfig === 'HIGH') ? this.highCpu : this.lowCpu;
+        const MEMORY = (ramConfig === 'HIGH') ? this.highMemory * 1024 : this.lowMemory * 1024;   // 12GB or 2GB
         const random = randomstring.generate({
             length: 5,
             charset: 'alphanumeric',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,7 +88,17 @@ describe('index', () => {
                 token: 'api_key2',
                 host: 'kubernetes2',
                 jobsNamespace: 'baz',
-                baseImage: 'hyperctl'
+                baseImage: 'hyperctl',
+                resources: {
+                    cpu: {
+                        high: 8,
+                        low: 1
+                    },
+                    memory: {
+                        high: 5,
+                        low: 1
+                    }
+                }
             },
             prefix: 'beta_',
             launchVersion: 'v1.2.3'
@@ -99,6 +109,10 @@ describe('index', () => {
         assert.equal(executor.launchVersion, 'v1.2.3');
         assert.equal(executor.jobsNamespace, 'baz');
         assert.equal(executor.baseImage, 'hyperctl');
+        assert.equal(executor.highCpu, 8);
+        assert.equal(executor.lowCpu, 1);
+        assert.equal(executor.highMemory, 5);
+        assert.equal(executor.lowMemory, 1);
     });
 
     it('allow empty options', () => {
@@ -109,6 +123,10 @@ describe('index', () => {
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.prefix, '');
         assert.equal(executor.token, '');
+        assert.equal(executor.highCpu, 6);
+        assert.equal(executor.lowCpu, 2);
+        assert.equal(executor.highMemory, 12);
+        assert.equal(executor.lowMemory, 2);
     });
 
     it('extends base class', () => {


### PR DESCRIPTION
Currently, it defaults to require 2 cpu to start the pod. Our nodes have only 2 cpu so a lot of builds get stuck. This PR makes it configurable by the cluster, so we can modify this value to something smaller.