### PR TITLE
feat(827) use tolerations config

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,10 +100,24 @@ class K8sVMExecutor extends Executor {
             launcher_version: this.launchVersion,
             base_image: this.baseImage
         });
+
+        const podConfig = yaml.safeLoad(podTemplate);
+
+        const tolerations = hoek.reach(config, 'tolerations', { default: [] });
+
+        if (Array.isArray(tolerations) && tolerations.length) {
+            podConfig.spec.tolerations = tolerations.map(toleration => ({
+                key: toleration.key,
+                value: toleration.value,
+                effect: toleration.effect || 'NoSchedule',
+                operator: toleration.operator || 'Equal'
+            }));
+        }
+
         const options = {
             uri: this.podsUrl,
             method: 'POST',
-            body: yaml.safeLoad(podTemplate),
+            body: podConfig,
             headers: { Authorization: `Bearer ${this.token}` },
             strictSSL: false,
             json: true

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ class K8sVMExecutor extends Executor {
         const podConfig = yaml.safeLoad(podTemplate);
 
         if (this.tolerations) {
+            podConfig.spec = podConfig.spec || {};
             podConfig.spec.tolerations = this.tolerations;
         }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "circuit-fuses": "^2.1.0",
         "hoek": "^5.0.2",
         "js-yaml": "^3.6.1",
+        "lodash": "^4.17.4",
         "randomstring": "^1.1.5",
         "requestretry": "^1.12.2",
         "screwdriver-executor-base": "^5.2.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -338,7 +338,7 @@ describe('index', () => {
             });
         });
 
-        it('sets tolerations with appropriate config', () => {
+        it('sets tolerations and node affinity with appropriate node config', () => {
             const spec = {};
 
             postConfig.body.spec = spec;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -336,6 +336,27 @@ describe('index', () => {
             });
         });
 
+        it('sets tolerations with appropriate config', () => {
+            postConfig.tolerations = [{
+                key: 'key',
+                value: 'value',
+                effect: 'NoSchedule',
+                operator: 'Equal'
+            }];
+
+            return executor.start({
+                tolerations: [{ key: 'key', value: 'value' }],
+                buildId: testBuildId,
+                container: testContainer,
+                token: testToken,
+                apiUri: testApiUri
+            }).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall,
+                    sinon.match(getConfig));
+            });
+        });
+
         it('returns error when request responds with error', () => {
             const error = new Error('lol');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -338,7 +338,7 @@ describe('index', () => {
             });
         });
 
-        it.only('sets tolerations with appropriate config', () => {
+        it('sets tolerations with appropriate config', () => {
             postConfig.body.spec = {};
             postConfig.body.spec.tolerations = [{
                 key: 'key',
@@ -361,6 +361,8 @@ describe('index', () => {
                 },
                 prefix: 'beta_'
             });
+
+            delete getConfig.retryStrategy;
 
             return executor.start({
                 buildId: testBuildId,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -223,28 +223,7 @@ describe('index', () => {
     });
 
     describe('start', () => {
-        const postConfig = {
-            uri: podsUrl,
-            method: 'POST',
-            body: {
-                metadata: {
-                    cpu: 2,
-                    memory: 2048,
-                    name: 'beta_15',
-                    container: testContainer,
-                    launchVersion: testLaunchVersion
-                },
-                command: [
-                    '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
-                    + '15'
-                ]
-            },
-            headers: {
-                Authorization: 'Bearer api_key'
-            },
-            strictSSL: false,
-            json: true
-        };
+        let postConfig;
         let getConfig;
 
         const fakeStartResponse = {
@@ -266,6 +245,29 @@ describe('index', () => {
         };
 
         beforeEach(() => {
+            postConfig = {
+                uri: podsUrl,
+                method: 'POST',
+                body: {
+                    metadata: {
+                        cpu: 2,
+                        memory: 2048,
+                        name: 'beta_15',
+                        container: testContainer,
+                        launchVersion: testLaunchVersion
+                    },
+                    command: [
+                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
+                        + '15'
+                    ]
+                },
+                headers: {
+                    Authorization: 'Bearer api_key'
+                },
+                strictSSL: false,
+                json: true
+            };
+
             getConfig = {
                 uri: `${podsUrl}/testpod/status`,
                 method: 'GET',
@@ -336,16 +338,31 @@ describe('index', () => {
             });
         });
 
-        it('sets tolerations with appropriate config', () => {
-            postConfig.tolerations = [{
+        it.only('sets tolerations with appropriate config', () => {
+            postConfig.body.spec = {};
+            postConfig.body.spec.tolerations = [{
                 key: 'key',
                 value: 'value',
                 effect: 'NoSchedule',
                 operator: 'Equal'
             }];
 
+            executor = new Executor({
+                ecosystem: {
+                    api: testApiUri,
+                    store: testStoreUri
+                },
+                fusebox: { retry: { minTimeout: 1 } },
+                kubernetes: {
+                    tolerations: [{ key: 'key', value: 'value' }],
+                    token: 'api_key',
+                    host: 'kubernetes.default',
+                    baseImage: 'hyperctl'
+                },
+                prefix: 'beta_'
+            });
+
             return executor.start({
-                tolerations: [{ key: 'key', value: 'value' }],
                 buildId: testBuildId,
                 container: testContainer,
                 token: testToken,


### PR DESCRIPTION
# Context
Allow `executor-k8s-vm` to use toleration config passed in by API so that build pods can work with taints set by cluster administrator.

# Objective
Parse `tolerations` config and use that in pod spec.

Blocked on this PR https://github.com/screwdriver-cd/data-schema/pull/197