### PR TITLE
Expose $METRIC_HOST and $NODE_ID to K8 pod

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -40,6 +40,11 @@ spec:
          "--id_with_prefix", "{{build_id_with_prefix}}",
          "--build_token", "{{token}}"
           ]
+    env:
+    - name: NODE_ID
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
     volumeMounts:
     - mountPath: /var/run
       name: hyper-socket

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -41,6 +41,8 @@ spec:
          "--build_token", "{{token}}"
           ]
     env:
+    - name: METRIC_HOST
+      value: "{{metric_host}}"
     - name: NODE_ID
       valueFrom:
         fieldRef:

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ class K8sVMExecutor extends Executor {
      * @param  {Object} options.ecosystem                             Screwdriver Ecosystem
      * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
      * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
+     * @param  {Object} options.ecosystem.metric_host                 Hostname for metrics service, or pushgateway
      * @param  {Object} options.kubernetes                            Kubernetes configuration
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
      * @param  {String} [options.kubernetes.host=kubernetes.default]  Kubernetes hostname

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class K8sVMExecutor extends Executor {
      * @param  {Object} options                                       Configuration options
      * @param  {Object} options.ecosystem                             Screwdriver Ecosystem
      * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
-     * @param  {Object} options.ecosystem.metric_host                 Hostname for metrics service, or pushgateway
+     * @param  {Object} [options.ecosystem.metric_host]               Hostname for metrics service, or pushgateway
      * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.kubernetes                            Kubernetes configuration
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)

--- a/index.js
+++ b/index.js
@@ -61,8 +61,8 @@ class K8sVMExecutor extends Executor {
      * @param  {Object} options                                       Configuration options
      * @param  {Object} options.ecosystem                             Screwdriver Ecosystem
      * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
-     * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.ecosystem.metric_host                 Hostname for metrics service, or pushgateway
+     * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.kubernetes                            Kubernetes configuration
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
      * @param  {String} [options.kubernetes.host=kubernetes.default]  Kubernetes hostname

--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ class K8sVMExecutor extends Executor {
 
         this.kubernetes = options.kubernetes || {};
         this.ecosystem = options.ecosystem;
-        this.ecosystem.metric_host = hoek.reach(options.ecosystem, 'metric_host') || '';
 
         if (this.kubernetes.token) {
             this.token = this.kubernetes.token;
@@ -140,7 +139,7 @@ class K8sVMExecutor extends Executor {
             container: config.container,
             api_uri: this.ecosystem.api,
             store_uri: this.ecosystem.store,
-            metric_host: this.ecosystem.metric_host,
+            metric_host: hoek.reach(this.ecosystem, 'metric_host', { default: '' }),
             token: config.token,
             launcher_version: this.launchVersion,
             base_image: this.baseImage

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ class K8sVMExecutor extends Executor {
 
         this.kubernetes = options.kubernetes || {};
         this.ecosystem = options.ecosystem;
+        this.ecosystem.metric_host = hoek.reach(options.ecosystem, 'metric_host') || '';
 
         if (this.kubernetes.token) {
             this.token = this.kubernetes.token;

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ class K8sVMExecutor extends Executor {
             container: config.container,
             api_uri: this.ecosystem.api,
             store_uri: this.ecosystem.store,
+            metric_host: this.ecosystem.metric_host,
             token: config.token,
             launcher_version: this.launchVersion,
             base_image: this.baseImage


### PR DESCRIPTION
# Context

To provide users with the ability to gather metrics about their Kubernetes clusters, it would be nice to expose two environment variables, $METRIC_HOST and $NODE_ID to the Kubernetes pod. $METRIC_HOST would be injected from Screwdriver's ecosystem in `default.yaml`.

# Objective

Modify the `pod.yaml.tim` to inject environment variables into a Kubernetes pod, so users can collect and send metric data.

# Related Links:

* How to get a pod's node ID: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

