### PR TITLE
feat: Expose $METRIC_HOST and $NODE_ID to K8 pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.kubernetes.token | String | '' | The JWT token used for authenticating to the Kubernetes cluster. (If not passed in, we will read from `/var/run/secrets/kubernetes.io/serviceaccount/token`.) |
 | config.kubernetes.host | String | 'kubernetes.defaults' | The hostname for the Kubernetes cluster (kubernetes) |
 | config.kubernetes.nodeSelectors| Object | | Object representing node label-value pairs https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node|
-| config.ecosystem | Object | | Screwdriver Ecosystem (ui, api, store, etc.) |
+| config.ecosystem | Object | | Screwdriver Ecosystem (ui, api, store, metrics, etc.) |
 | config.launchVersion | String | 'stable' | Launcher container version to use (stable) |
 | config.prefix | String | '' |Prefix to container names ("") |
 | config.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class K8sVMExecutor extends Executor {
      * @param  {Object} options                                       Configuration options
      * @param  {Object} options.ecosystem                             Screwdriver Ecosystem
      * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
-     * @param  {Object} [options.ecosystem.metric_host]               Hostname for metrics service, or pushgateway
+     * @param  {Object} [options.ecosystem.metricHost]                Hostname for metrics service, or pushgateway
      * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.kubernetes                            Kubernetes configuration
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
@@ -140,7 +140,7 @@ class K8sVMExecutor extends Executor {
             container: config.container,
             api_uri: this.ecosystem.api,
             store_uri: this.ecosystem.store,
-            metric_host: hoek.reach(this.ecosystem, 'metric_host', { default: '' }),
+            metric_host: hoek.reach(this.ecosystem, 'metricHost', { default: '' }),
             token: config.token,
             launcher_version: this.launchVersion,
             base_image: this.baseImage


### PR DESCRIPTION
# Context

To provide users with the ability to gather metrics about their Kubernetes clusters, it would be nice to expose two environment variables, $METRIC_HOST and $NODE_ID to the Kubernetes pod. $METRIC_HOST would be injected from Screwdriver's ecosystem in `default.yaml`.

# Objective

Modify the `pod.yaml.tim` to inject environment variables into a Kubernetes pod, so users can collect and send metric data.

# Related Links:

* How to get a pod's node ID: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
* Screwdriver config PR: https://github.com/screwdriver-cd/screwdriver/pull/872
* Old PR that didn't trigger semantic-release: https://github.com/screwdriver-cd/executor-k8s-vm/pull/22