### PR TITLE
fix: Clarify "metric host" should be a Prometheus pushgateway URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.kubernetes.token | String | '' | The JWT token used for authenticating to the Kubernetes cluster. (If not passed in, we will read from `/var/run/secrets/kubernetes.io/serviceaccount/token`.) |
 | config.kubernetes.host | String | 'kubernetes.defaults' | The hostname for the Kubernetes cluster (kubernetes) |
 | config.kubernetes.nodeSelectors| Object | | Object representing node label-value pairs https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node|
-| config.ecosystem | Object | | Screwdriver Ecosystem (ui, api, store, metrics, etc.) |
+| config.ecosystem | Object | | Screwdriver Ecosystem (ui, api, store, pushgateway, etc.) |
 | config.launchVersion | String | 'stable' | Launcher container version to use (stable) |
 | config.prefix | String | '' |Prefix to container names ("") |
 | config.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -41,8 +41,8 @@ spec:
          "--build_token", "{{token}}"
           ]
     env:
-    - name: METRIC_HOST
-      value: "{{metric_host}}"
+    - name: PUSHGATEWAY_URL
+      value: "{{pushgateway_url}}"
     - name: NODE_ID
       valueFrom:
         fieldRef:

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class K8sVMExecutor extends Executor {
      * @param  {Object} options                                       Configuration options
      * @param  {Object} options.ecosystem                             Screwdriver Ecosystem
      * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
-     * @param  {Object} [options.ecosystem.metricHost]                Hostname for metrics service, or pushgateway
+     * @param  {Object} [options.ecosystem.pushgatewayUrl]            Pushgateway URL for Prometheus
      * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.kubernetes                            Kubernetes configuration
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
@@ -140,7 +140,7 @@ class K8sVMExecutor extends Executor {
             container: config.container,
             api_uri: this.ecosystem.api,
             store_uri: this.ecosystem.store,
-            metric_host: hoek.reach(this.ecosystem, 'metricHost', { default: '' }),
+            pushgateway_url: hoek.reach(this.ecosystem, 'pushgatewayUrl', { default: '' }),
             token: config.token,
             launcher_version: this.launchVersion,
             base_image: this.baseImage


### PR DESCRIPTION
It was brought to my attention that "metric host" is vague, and implies that entering a URL to your metrics service would magically set everything up.

To reflect that this feature has been designed to only support [Prometheus pushgateways](https://github.com/prometheus/pushgateway), I've changed the nomenclature and comments to reflect that.