### PR TITLE
fix: build timeout defined in minutes

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const tinytim = require('tinytim');
 const yaml = require('js-yaml');
 const _ = require('lodash');
 
-const DEFAULT_BUILD_TIMEOUT = 5400;   // 90 minutes in seconds
+const DEFAULT_BUILD_TIMEOUT = 90;   // 90 minutes
 const MAXATTEMPTS = 5;
 const RETRYDELAY = 3000;
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
@@ -70,7 +70,7 @@ class K8sVMExecutor extends Executor {
      * @param  {String} [options.kubernetes.host=kubernetes.default]  Kubernetes hostname
      * @param  {String} [options.kubernetes.jobsNamespace=default]    Pods namespace for Screwdriver Jobs
      * @param  {String} [options.kubernetes.baseImage]                Base image for the pod
-     * @param  {Number} [options.kubernetes.buildTimeout=5400]        Number of seconds to allow a build to run before considering it is timed out
+     * @param  {Number} [options.kubernetes.buildTimeout=90]          Number of minutes to allow a build to run before considering it is timed out
      * @param  {String} [options.kubernetes.resources.cpu.high=6]     Value for HIGH CPU (in cores)
      * @param  {Number} [options.kubernetes.resources.cpu.low=2]      Value for LOW CPU (in cores)
      * @param  {Number} [options.kubernetes.resources.memory.high=12] Value for HIGH memory (in GB)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,7 +85,7 @@ describe('index', () => {
         assert.equal(executor.host, 'kubernetes.default');
         executor = new Executor({
             kubernetes: {
-                buildTimeout: 3600,
+                buildTimeout: 30,
                 nodeSelectors: {},
                 token: 'api_key2',
                 host: 'kubernetes2',
@@ -105,7 +105,7 @@ describe('index', () => {
             prefix: 'beta_',
             launchVersion: 'v1.2.3'
         });
-        assert.equal(executor.buildTimeout, 3600);
+        assert.equal(executor.buildTimeout, 30);
         assert.equal(executor.baseImage, 'hyperctl');
         assert.equal(executor.prefix, 'beta_');
         assert.equal(executor.token, 'api_key2');
@@ -121,7 +121,7 @@ describe('index', () => {
     it('allow empty options', () => {
         fsMock.existsSync.returns(false);
         executor = new Executor();
-        assert.equal(executor.buildTimeout, 5400);
+        assert.equal(executor.buildTimeout, 90);
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.host, 'kubernetes.default');
         assert.equal(executor.launchVersion, 'stable');
@@ -261,7 +261,7 @@ describe('index', () => {
                         launchVersion: testLaunchVersion
                     },
                     command: [
-                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 5400 '
+                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 90 '
                         + '15'
                     ]
                 },


### PR DESCRIPTION
## Context

The units of time for `build-timeout` is in minutes.

## Objective

Correct all assumptions of _build-timeout_ from seconds to minutes.

## References

* Feature issue
   * https://github.com/screwdriver-cd/screwdriver/issues/545