### PR TITLE
fix(972): fix when a selector is empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ function setNodeSelector(podConfig, nodeSelectors) {
  * @param {Object} preferredNodeSelectors key-value pairs of preferred node selectors
  */
 function setPreferredNodeSelector(podConfig, preferredNodeSelectors) {
-    if (!preferredNodeSelectors || typeof preferredNodeSelectors !== 'object') {
+    if (!preferredNodeSelectors || typeof preferredNodeSelectors !== 'object' ||
+        !Object.keys(preferredNodeSelectors).length) {
         return;
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -151,6 +151,10 @@ describe('index', () => {
                 api: testApiUri,
                 store: testStoreUri
             },
+            kubernetes: {
+                nodeSelectors: {},
+                preferredNodeSelectors: {}
+            },
             fusebox: { retry: { minTimeout: 1 } },
             prefix: 'beta_'
         });


### PR DESCRIPTION
This PR adds missing if statement and fixes test data to be more detail.

Related: screwdriver-cd/screwdriver#972