### PR TITLE
fix(545): cluster configurable build timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,9 @@ class K8sVMExecutor extends Executor {
         const annotations = hoek.reach(config, 'annotations', { default: {} });
         const cpuConfig = hoek.reach(config, 'annotations', { default: {} })[CPU_RESOURCE];
         const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
-        const buildTimeout = annotations[ANNOTATION_BUILD_TIMEOUT] || this.buildTimeout;
+        const buildTimeout = annotations[ANNOTATION_BUILD_TIMEOUT]
+            ? Math.min(annotations[ANNOTATION_BUILD_TIMEOUT], this.buildTimeout)
+            : this.buildTimeout;
         const CPU = (cpuConfig === 'HIGH') ? this.highCpu : this.lowCpu;
         const MEMORY = (ramConfig === 'HIGH') ? this.highMemory * 1024 : this.lowMemory * 1024;   // 12GB or 2GB
         const random = randomstring.generate({

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const yaml = require('js-yaml');
 const _ = require('lodash');
 
 const DEFAULT_BUILD_TIMEOUT = 90;   // 90 minutes
+const MAX_BUILD_TIMEOUT = 120;       // 120 minutes
 const MAXATTEMPTS = 5;
 const RETRYDELAY = 3000;
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
@@ -114,6 +115,7 @@ class K8sVMExecutor extends Executor {
      * @param  {String} [options.kubernetes.jobsNamespace=default]    Pods namespace for Screwdriver Jobs
      * @param  {String} [options.kubernetes.baseImage]                Base image for the pod
      * @param  {Number} [options.kubernetes.buildTimeout=90]          Number of minutes to allow a build to run before considering it is timed out
+     * @param  {Number} [options.kubernetes.maxBuildTimeout=120]      Max timeout user can configure up to
      * @param  {String} [options.kubernetes.resources.cpu.high=6]     Value for HIGH CPU (in cores)
      * @param  {Number} [options.kubernetes.resources.cpu.low=2]      Value for LOW CPU (in cores)
      * @param  {Number} [options.kubernetes.resources.memory.high=12] Value for HIGH memory (in GB)
@@ -143,6 +145,7 @@ class K8sVMExecutor extends Executor {
         this.jobsNamespace = this.kubernetes.jobsNamespace || 'default';
         this.baseImage = this.kubernetes.baseImage;
         this.buildTimeout = this.kubernetes.buildTimeout || DEFAULT_BUILD_TIMEOUT;
+        this.maxBuildTimeout = this.kubernetes.maxBuildTimeout || MAX_BUILD_TIMEOUT;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
         this.highCpu = hoek.reach(options, 'kubernetes.resources.cpu.high', { default: 6 });
@@ -173,9 +176,6 @@ class K8sVMExecutor extends Executor {
         const annotations = hoek.reach(config, 'annotations', { default: {} });
         const cpuConfig = hoek.reach(config, 'annotations', { default: {} })[CPU_RESOURCE];
         const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
-        const buildTimeout = annotations[ANNOTATION_BUILD_TIMEOUT]
-            ? Math.min(annotations[ANNOTATION_BUILD_TIMEOUT], this.buildTimeout)
-            : this.buildTimeout;
         const CPU = (cpuConfig === 'HIGH') ? this.highCpu : this.lowCpu;
         const MEMORY = (ramConfig === 'HIGH') ? this.highMemory * 1024 : this.lowMemory * 1024;   // 12GB or 2GB
         const random = randomstring.generate({
@@ -183,6 +183,9 @@ class K8sVMExecutor extends Executor {
             charset: 'alphanumeric',
             capitalization: 'lowercase'
         });
+        const buildTimeout = annotations[ANNOTATION_BUILD_TIMEOUT]
+            ? Math.min(annotations[ANNOTATION_BUILD_TIMEOUT], this.maxBuildTimeout)
+            : this.buildTimeout;
         const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
             cpu: CPU,
             memory: MEMORY,

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class K8sVMExecutor extends Executor {
      * @param  {String} [options.kubernetes.jobsNamespace=default]    Pods namespace for Screwdriver Jobs
      * @param  {String} [options.kubernetes.baseImage]                Base image for the pod
      * @param  {Number} [options.kubernetes.buildTimeout=90]          Number of minutes to allow a build to run before considering it is timed out
-     * @param  {Number} [options.kubernetes.maxBuildTimeout=120]      Max timeout user can configure up to
+     * @param  {Number} [options.kubernetes.maxBuildTimeout=120]      Max timeout user can configure up to (in minutes)
      * @param  {String} [options.kubernetes.resources.cpu.high=6]     Value for HIGH CPU (in cores)
      * @param  {Number} [options.kubernetes.resources.cpu.low=2]      Value for LOW CPU (in cores)
      * @param  {Number} [options.kubernetes.resources.memory.high=12] Value for HIGH memory (in GB)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -582,14 +582,26 @@ describe('index', () => {
 
         it('sets the build timeout', () => {
             postConfig.body.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 10800 15'
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 45 15'
             ];
-            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 10800 };
+            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 45 };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
-                assert.calledWith(requestRetryMock.secondCall,
-                    sinon.match(getConfig));
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
+
+        it('uses cluster build timeout if user specified a higher timeout', () => {
+            executor.buildTimeout = 20;
+            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 120 };
+            postConfig.body.command = [
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 20 15'
+            ];
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
             });
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -581,10 +581,12 @@ describe('index', () => {
         });
 
         it('sets the build timeout', () => {
+            const testTimeout = 45;
+
             postConfig.body.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 45 15'
+                `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${testTimeout} 15`
             ];
-            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 45 };
+            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': testTimeout };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -596,7 +598,8 @@ describe('index', () => {
             executor.buildTimeout = 20;
             fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 120 };
             postConfig.body.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 20 15'
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg ' +
+                `${executor.buildTimeout} 15`
             ];
 
             return executor.start(fakeStartConfig).then(() => {


### PR DESCRIPTION
Allow cluster admin to configure default build timeout for the cluster

Related: https://github.com/screwdriver-cd/screwdriver/issues/545