### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const tinytim = require('tinytim');
 const yaml = require('js-yaml');
 const _ = require('lodash');
 
-const DEFAULT_BUILD_TIMEOUT = 90;   // 90 minutes
-const MAX_BUILD_TIMEOUT = 120;       // 120 minutes
+const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
+const MAX_BUILD_TIMEOUT = 120; // 120 minutes
 const MAXATTEMPTS = 5;
 const RETRYDELAY = 3000;
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const tinytim = require('tinytim');
 const yaml = require('js-yaml');
 const _ = require('lodash');
 
-const DEFAULT_BUILD_TIMEOUT = 90;   // 90 minutes
+const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
 const MAXATTEMPTS = 5;
 const RETRYDELAY = 3000;
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
@@ -175,7 +175,7 @@ class K8sVMExecutor extends Executor {
         const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
         const buildTimeout = annotations[ANNOTATION_BUILD_TIMEOUT] || this.buildTimeout;
         const CPU = (cpuConfig === 'HIGH') ? this.highCpu : this.lowCpu;
-        const MEMORY = (ramConfig === 'HIGH') ? this.highMemory * 1024 : this.lowMemory * 1024;   // 12GB or 2GB
+        const MEMORY = (ramConfig === 'HIGH') ? this.highMemory * 1024 : this.lowMemory * 1024; // 12GB or 2GB
         const random = randomstring.generate({
             length: 5,
             charset: 'alphanumeric',

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     },
     "devDependencies": {
         "chai": "^3.5.0",
-        "eslint": "^3.2.2",
-        "eslint-config-screwdriver": "^2.0.0",
+        "eslint": "^4.19.1",
+        "eslint-config-screwdriver": "^3.0.0",
         "jenkins-mocha": "^4.0.0",
         "mockery": "^2.0.0",
         "rewire": "^3.0.2",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-  image: node:6
+  image: node:8
 
 jobs:
   main:


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`

#### Additional changes

* Update ESLint and `eslint-config-screwdriver`