### PR TITLE
feat: cp hab cache to sdlauncher volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc_output/*

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -64,7 +64,7 @@ spec:
   initContainers:
   - name: launcher
     image: screwdrivercd/launcher:{{launcher_version}}
-    command: ['/bin/sh', '-c', 'cp -a /opt/sd/* /opt/launcher']
+    command: ['/bin/sh', '-c', 'cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
     "dependencies": {
         "circuit-fuses": "^2.1.0",
         "eslint-plugin-import": "^2.11.0",
-        "hoek": "^5.0.2",
-        "js-yaml": "^3.6.1",
-        "lodash": "^4.17.4",
+        "hoek": "^5.0.3",
+        "js-yaml": "^3.12.0",
+        "lodash": "^4.17.10",
         "randomstring": "^1.1.5",
-        "requestretry": "^1.12.2",
+        "requestretry": "^1.13.0",
         "screwdriver-executor-base": "^6.1.0",
         "tinytim": "^0.1.1"
     }


### PR DESCRIPTION
This PR cp `hab` cache to the exsiting`sdlauncher` volume. Later I will open another PR in` hyperctl-image` to copy ` /opt/launcher/hab` to `/hab`. The reason why we don't mount it to `\hab` directly is due to security concern. `/hab` need to be writable, but all volume mounts for vm should be read-only since it's shared between VM and the host directly.

https://github.com/screwdriver-cd/hyperctl-image/blob/master/scripts/hyper-pod-template.json#L17

Related to https://github.com/screwdriver-cd/screwdriver/issues/877
