### PR TITLE
feat(1167): [2][small] remove calling exchangeTokenForBuild method

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,7 @@ describe('index', () => {
     let fsMock;
     let executor;
     const testBuildId = 15;
-    let testToken = 'abcdefg';
+    const testToken = 'abcdefg';
     const testApiUri = 'http://api:8080';
     const testStoreUri = 'http://store:8080';
     const testContainer = 'node:4';
@@ -375,7 +375,7 @@ describe('index', () => {
                     },
                     spec: testPodSpec,
                     command: [
-                        '/opt/sd/launch http://api:8080 http://store:8080 someBuildToken '
+                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
                         + `${DEFAULT_BUILD_TIMEOUT} 15`
                     ]
                 },
@@ -411,13 +411,6 @@ describe('index', () => {
                 null, fakeStartResponse, fakeStartResponse.body);
             requestRetryMock.withArgs(sinon.match({ method: 'GET' })).yieldsAsync(
                 null, fakeGetResponse, fakeGetResponse.body);
-
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
-        });
-
-        afterEach(() => {
-            testToken = 'abcdefg';
         });
 
         it('successfully calls start', () =>
@@ -491,8 +484,6 @@ describe('index', () => {
                 },
                 prefix: 'beta_'
             });
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
 
             getConfig.retryStrategy = executor.podRetryStrategy;
 
@@ -549,9 +540,6 @@ describe('index', () => {
                     preferredNodeSelectors: { key: 'value', foo: 'bar' }
                 }
             });
-
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
 
             getConfig.retryStrategy = executor.podRetryStrategy;
 
@@ -639,7 +627,7 @@ describe('index', () => {
 
         it('sets the build timeout to default build timeout if not configured by user', () => {
             postConfig.body.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 someBuildToken '
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
                 + `${DEFAULT_BUILD_TIMEOUT} 15`
             ];
 
@@ -653,7 +641,7 @@ describe('index', () => {
             const userTimeout = 45;
 
             postConfig.body.command = [
-                `/opt/sd/launch http://api:8080 http://store:8080 someBuildToken ${userTimeout} 15`
+                `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${userTimeout} 15`
             ];
             fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': userTimeout };
 
@@ -666,7 +654,7 @@ describe('index', () => {
         it('sets the timeout to maxBuildTimeout if user specified a higher timeout', () => {
             fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 220 };
             postConfig.body.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 someBuildToken '
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
                 + `${MAX_BUILD_TIMEOUT} 15`
             ];
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For issue https://github.com/screwdriver-cd/screwdriver/issues/1167 , we should exchange temporary JWT token in launcher, not in executor-*.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
I removed calling exchangeTokenForBuild method form executor-k8s-vm.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
related PR:
launcher: https://github.com/screwdriver-cd/launcher/pull/201
executor-k8s: https://github.com/screwdriver-cd/executor-k8s/pull/88
executor-docker: https://github.com/screwdriver-cd/executor-docker/pull/27
executor-jenkins: https://github.com/screwdriver-cd/executor-jenkins/pull/23
