### PR TITLE
fix: pull in new circuit breaker

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Executor = require('screwdriver-executor-base');
-const Fusebox = require('circuit-fuses');
+const Fusebox = require('circuit-fuses').breaker;
 const fs = require('fs');
 const hoek = require('hoek');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
         "sinon": "^5.0.10"
     },
     "dependencies": {
-        "circuit-fuses": "^2.1.0",
-        "eslint-plugin-import": "^2.11.0",
-        "hoek": "^5.0.3",
+        "circuit-fuses": "^4.0.0",
+        "eslint-plugin-import": "^2.14.0",
+        "hoek": "^5.0.4",
         "js-yaml": "^3.12.0",
         "lodash": "^4.17.10",
         "randomstring": "^1.1.5",
         "requestretry": "^1.13.0",
-        "screwdriver-executor-base": "^6.1.0",
+        "screwdriver-executor-base": "^6.2.0",
         "tinytim": "^0.1.1"
     }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -341,7 +341,6 @@ describe('index', () => {
         let postConfig;
         let getConfig;
         let fakeStartConfig;
-        let exchangeTokenStub;
 
         const fakeStartResponse = {
             statusCode: 201,
@@ -510,9 +509,6 @@ describe('index', () => {
                     preferredNodeSelectors: { key: 'value', foo: 'bar' }
                 }
             });
-
-            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves('someBuildToken');
 
             getConfig.retryStrategy = executor.podRetryStrategy;
 


### PR DESCRIPTION
Interface for circuit breaker got changed a long time ago but we never published it.

https://github.com/screwdriver-cd/circuit-fuses/blob/master/index.js#L229

pull in: https://github.com/screwdriver-cd/circuit-fuses/pull/23
https://github.com/screwdriver-cd/circuit-fuses/pull/24