### PR TITLE
fix: add resources requests in k8s pod

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -28,7 +28,8 @@ spec:
       privileged: true
     resources:
       limits:
-        memory: 2Gi
+        cpu: "{{cpu}}"
+        memory: {{memory}}Mi
     command: ["/sd/hyper-runner.sh"]
     args: [
          "--cpu", "{{cpu}}",


### PR DESCRIPTION
add resources requests in k8s pod.

when k8s allocate resources it will simply sum up the requested resources for all the k8s pods. By reserving this resources, we can make sure hyper vm gets enough resources. This vm-launcher pod won't actually consume that much.
