### PR TITLE
fix(757): set build status msg if pod is still pending after maxRetry

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,32 @@ class K8sVMExecutor extends Executor {
     }
 
     /**
+     * Update build status message
+     * @method updateStatusMessage
+     * @param  {Object}          config                 build config of the job
+     * @param  {String}          config.apiUri          screwdriver base api uri
+     * @param  {Number}          config.buildId         build id
+     * @param  {String}          config.statusMessage   build status message
+     * @param  {String}          config.token           build temporal jwt token
+     * @return {Promise}
+     */
+    updateStatusMessage(config) {
+        const { apiUri, buildId, statusMessage, token } = config;
+        const statusMessageOptions = {
+            json: true,
+            method: 'PUT',
+            uri: `${apiUri}/v4/builds/${buildId}`,
+            body: { statusMessage },
+            headers: { Authorization: `Bearer ${token}` },
+            strictSSL: false,
+            maxAttempts: MAXATTEMPTS,
+            retryDelay: RETRYDELAY
+        };
+
+        return this.breaker.runCommand(statusMessageOptions);
+    }
+
+    /**
      * Starts a k8s build
      * @method start
      * @param  {Object}   config                A configuration object
@@ -269,6 +295,15 @@ class K8sVMExecutor extends Executor {
                 if (status === 'failed' || status === 'unknown') {
                     throw new Error('Failed to create pod. Pod status is:' +
                         `${JSON.stringify(resp.body.status, null, 2)}`);
+                }
+
+                if (status === 'pending') {
+                    return this.updateStatusMessage({
+                        apiUri: this.ecosystem.api,
+                        buildId: config.buildId,
+                        statusMessage: 'Waiting for resources to be available.',
+                        token: config.token
+                    });
                 }
 
                 return null;

--- a/package.json
+++ b/package.json
@@ -43,21 +43,21 @@
     "devDependencies": {
         "chai": "^3.5.0",
         "eslint": "^4.19.1",
-        "eslint-config-screwdriver": "^3.0.0",
+        "eslint-config-screwdriver": "^3.0.1",
         "jenkins-mocha": "^4.0.0",
         "mockery": "^2.0.0",
         "rewire": "^3.0.2",
         "sinon": "^5.0.10"
     },
     "dependencies": {
-        "circuit-fuses": "^4.0.0",
+        "circuit-fuses": "^4.0.3",
         "eslint-plugin-import": "^2.14.0",
         "hoek": "^5.0.4",
         "js-yaml": "^3.12.0",
         "lodash": "^4.17.10",
         "randomstring": "^1.1.5",
         "requestretry": "^1.13.0",
-        "screwdriver-executor-base": "^6.2.0",
+        "screwdriver-executor-base": "^6.2.1",
         "tinytim": "^0.1.1"
     }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -340,6 +340,7 @@ describe('index', () => {
     describe('start', () => {
         let postConfig;
         let getConfig;
+        let putConfig;
         let fakeStartConfig;
 
         const fakeStartResponse = {
@@ -396,6 +397,21 @@ describe('index', () => {
                 retryDelay: RETRYDELAY,
                 // eslint-disable-next-line
                 retryStrategy: executor.podRetryStrategy
+            };
+
+            putConfig = {
+                uri: `${testApiUri}/v4/builds/${testBuildId}`,
+                method: 'PUT',
+                headers: {
+                    Authorization: `Bearer ${testToken}`
+                },
+                body: {
+                    statusMessage: 'Waiting for resources to be available.'
+                },
+                strictSSL: false,
+                maxAttempts: MAXATTEMPTS,
+                retryDelay: RETRYDELAY,
+                json: true
             };
 
             fakeStartConfig = {
@@ -580,6 +596,52 @@ describe('index', () => {
         });
 
         it('returns error when pod status is failed', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'failed'
+                    }
+                }
+            };
+            const returnMessage = 'Failed to create pod. Pod status is:' +
+                        `${JSON.stringify(returnResponse.body.status, null, 2)}`;
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(
+                null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(() => {
+                throw new Error('did not fail');
+            }, (err) => {
+                assert.equal(err.message, returnMessage);
+            });
+        });
+
+        it('update build status message when pod status is pending', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending'
+                    }
+                }
+            };
+
+            const returnResponseFromSDAPI = { statusCode: 200 };
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(
+                null, returnResponse, returnResponse.body);
+
+            requestRetryMock.withArgs(putConfig).yieldsAsync(
+                null, returnResponseFromSDAPI);
+
+            return executor.start(fakeStartConfig).then((resp) => {
+                assert.calledWith(requestRetryMock, putConfig);
+                assert.deepEqual(resp.statusCode, 200);
+            });
+        });
+
+        it('sets error when pod status is failed', () => {
             const returnResponse = {
                 statusCode: 200,
                 body: {


### PR DESCRIPTION
When there is no K8S resources available, the pod will be pending. To bubble up this info to user, we will set build status msg if pod status is still pending after maxRetry.

When the build status got changed to `Running`, api will clear out the status msg set before that.
https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/builds/update.js#L115


