### PR TITLE
feat(757): Change toleration key from disk to screwdriver.cd/disk

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,8 @@ class K8sVMExecutor extends Executor {
         this.highMemory = hoek.reach(options, 'kubernetes.resources.memory.high', { default: 12 });
         this.lowMemory = hoek.reach(options, 'kubernetes.resources.memory.low', { default: 2 });
         this.microMemory = hoek.reach(options, 'kubernetes.resources.memory.micro', { default: 1 });
+        this.diskLabel = hoek.reach(options, 'kubernetes.labels.disk',
+            { default: 'screwdriver.cd/disk' });
         this.podRetryStrategy = (err, response, body) => {
             const status = hoek.reach(body, 'status.phase');
 
@@ -253,7 +255,7 @@ class K8sVMExecutor extends Executor {
 
         const diskConfig = annotations[DISK_RESOURCE] || '';
         const nodeSelectors = diskConfig.toUpperCase() === 'HIGH' ?
-            { 'screwdriver.cd/disk': 'high' } : {};
+            { [this.diskLabel]: 'high' } : {};
 
         hoek.merge(nodeSelectors, this.nodeSelectors);
 

--- a/index.js
+++ b/index.js
@@ -252,7 +252,8 @@ class K8sVMExecutor extends Executor {
         const podConfig = yaml.safeLoad(podTemplate);
 
         const diskConfig = annotations[DISK_RESOURCE] || '';
-        const nodeSelectors = diskConfig.toUpperCase() === 'HIGH' ? { disk: 'high' } : {};
+        const nodeSelectors = diskConfig.toUpperCase() === 'HIGH' ?
+            { 'screwdriver.cd/disk': 'high' } : {};
 
         hoek.merge(nodeSelectors, this.nodeSelectors);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -559,7 +559,12 @@ describe('index', () => {
                     nodeSelectors: { key: 'value' },
                     token: 'api_key',
                     host: 'kubernetes.default',
-                    baseImage: 'hyperctl'
+                    baseImage: 'hyperctl',
+                    resources: {
+                        disk: {
+                            high: 'screwdriver.cd/disk'
+                        }
+                    }
                 },
                 prefix: 'beta_'
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,7 @@ describe('index', () => {
     };
     const testSpecWithDisk = {
         tolerations: [{
-            key: 'disk',
+            key: 'screwdriver.cd/disk',
             value: 'high',
             effect: 'NoSchedule',
             operator: 'Equal'
@@ -89,7 +89,7 @@ describe('index', () => {
                     nodeSelectorTerms: [
                         {
                             matchExpressions: [{
-                                key: 'disk',
+                                key: 'screwdriver.cd/disk',
                                 operator: 'In',
                                 values: ['high']
                             }]
@@ -544,7 +544,7 @@ describe('index', () => {
         });
 
         it('sets disk toleration and node affinity when disk is HIGH', () => {
-            fakeStartConfig.annotations = { 'beta.screwdriver.cd/disk': 'HIGH' };
+            fakeStartConfig.annotations = { 'beta.screwdriver.cd/disk': 'high' };
             const spec = _.merge({}, testSpecWithDisk, testPodSpec);
 
             postConfig.body.spec = spec;


### PR DESCRIPTION
## Context
We should use a less generic label than `disk=high`.

## Objective
Change the toleration/pod affinity key from `disk` to `screwdriver.cd/disk`.

## References
https://github.com/screwdriver-cd/screwdriver/issues/757