### PR TITLE
fix(757): Change setNodeSelector to use a single nodeSelectorTerm

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const DISK_RESOURCE = 'disk';
 const ANNOTATION_BUILD_TIMEOUT = 'timeout';
 const TOLERATIONS_PATH = 'spec.tolerations';
 const AFFINITY_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
-    'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms';
+    'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions';
 const AFFINITY_PREFERRED_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
     'preferredDuringSchedulingIgnoredDuringExecution';
 const PREFERRED_WEIGHT = 100;
@@ -49,11 +49,9 @@ function setNodeSelector(podConfig, nodeSelectors) {
             operator: 'Equal'
         });
         nodeAffinitySelectors.push({
-            matchExpressions: [{
-                key,
-                operator: 'In',
-                values: [nodeSelectors[key]]
-            }]
+            key,
+            operator: 'In',
+            values: [nodeSelectors[key]]
         });
     });
     const tmpNodeAffinitySelector = {};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,9 +92,7 @@ describe('index', () => {
                                 key: 'screwdriver.cd/disk',
                                 operator: 'In',
                                 values: ['high']
-                            }]
-                        }, {
-                            matchExpressions: [{
+                            }, {
                                 key: 'key',
                                 operator: 'In',
                                 values: ['value']


### PR DESCRIPTION
## Context
Our current implementation of `setNodeSelector` appends multiple `nodeSelectorTerms` to the spec. This leads to an `OR` scheduling behavior where the pod can be scheduled on any node that is labled with any of the `nodeSelectors`. 

I believe we desire an `AND` scheduling behavior where the pod can be scheduled on any node that is labled with ALL of the `nodeSelectors`. This PR changes the implementation of `setNodeSelector` to honor this `AND` behavior of scheduling.

## Objective
Update `setNodeSelector` to append multiple keys to a single `nodeSelectorTerm`

## References
https://github.com/screwdriver-cd/screwdriver/issues/757
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
https://github.com/kubernetes/kubernetes/issues/44349