### PR TITLE
fix(1261): pod delete immediately when build has stopped.

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,6 +341,9 @@ class K8sVMExecutor extends Executor {
         const options = {
             uri: this.podsUrl,
             method: 'DELETE',
+            json: {
+                gracePeriodSeconds: 0
+            },
             qs: {
                 labelSelector: `sdbuild=${this.prefix}${config.buildId}`
             },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -314,6 +314,9 @@ describe('index', () => {
         const deleteConfig = {
             uri: podsUrl,
             method: 'DELETE',
+            json: {
+                gracePeriodSeconds: 0
+            },
             qs: {
                 labelSelector: `sdbuild=beta_${testBuildId}`
             },


### PR DESCRIPTION
Same as following PR.
https://github.com/screwdriver-cd/executor-k8s/pull/97

# References
- Issues:
https://github.com/screwdriver-cd/screwdriver/issues/1261