### PR TITLE
fix(1378): [small] remove preStop hook

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -56,12 +56,6 @@ spec:
       name: sd-workspaces
     - mountPath: /opt/sd
       name: sdlauncher
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/bin/bash", "-c", "sleep 2;
-                    rm -rf /var/sd-workspaces/{{build_id_with_prefix}};
-                    hyperctl rm builder-{{build_id_with_prefix}}"]
   initContainers:
   - name: launcher
     image: {{launcher_image}}


### PR DESCRIPTION
This `preStop` hook is no longer working since https://github.com/screwdriver-cd/executor-k8s-vm/pull/46 . So it might be removable.
This cleanup commands move to `hyper-runner.sh` ( https://github.com/screwdriver-cd/hyperctl-image/pull/26 )

Related: https://github.com/screwdriver-cd/screwdriver/issues/1378