### PR TITLE
fix: add disk speed annotation [2]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "^3.0.4"
+                "acorn": "3.3.0"
             },
             "dependencies": {
                 "acorn": {
@@ -42,10 +42,10 @@
             "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
@@ -77,7 +77,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "array-union": {
@@ -86,7 +86,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -106,7 +106,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "assert-plus": {
@@ -141,9 +141,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -152,11 +152,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -165,7 +165,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -176,25 +176,25 @@
             "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-generator": "^6.26.0",
-                "babel-helpers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-register": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "convert-source-map": "^1.5.1",
-                "debug": "^2.6.9",
-                "json5": "^0.5.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.4",
-                "path-is-absolute": "^1.0.1",
-                "private": "^0.1.8",
-                "slash": "^1.0.0",
-                "source-map": "^0.5.7"
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.1",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.5.1",
+                "debug": "2.6.9",
+                "json5": "0.5.1",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
             }
         },
         "babel-generator": {
@@ -203,14 +203,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "detect-indent": "^4.0.0",
-                "jsesc": "^1.3.0",
-                "lodash": "^4.17.4",
-                "source-map": "^0.5.7",
-                "trim-right": "^1.0.1"
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             }
         },
         "babel-helpers": {
@@ -219,8 +219,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-messages": {
@@ -229,7 +229,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -238,11 +238,11 @@
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.11"
             }
         },
         "babel-register": {
@@ -251,13 +251,13 @@
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "home-or-tmp": "^2.0.0",
-                "lodash": "^4.17.4",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.4.15"
+                "babel-core": "6.26.3",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.7",
+                "home-or-tmp": "2.0.0",
+                "lodash": "4.17.11",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.4.18"
             }
         },
         "babel-runtime": {
@@ -266,8 +266,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "babel-template": {
@@ -276,11 +276,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.11"
             }
         },
         "babel-traverse": {
@@ -289,15 +289,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "globals": {
@@ -314,10 +314,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "1.0.3"
             }
         },
         "babylon": {
@@ -336,7 +336,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "brace-expansion": {
@@ -344,7 +344,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -376,7 +376,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "^0.2.0"
+                "callsites": "0.2.0"
             }
         },
         "callsites": {
@@ -396,9 +396,9 @@
             "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
             "dev": true,
             "requires": {
-                "assertion-error": "^1.0.1",
-                "deep-eql": "^0.1.3",
-                "type-detect": "^1.0.0"
+                "assertion-error": "1.0.2",
+                "deep-eql": "0.1.3",
+                "type-detect": "1.0.0"
             }
         },
         "chalk": {
@@ -407,9 +407,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -418,7 +418,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "supports-color": {
@@ -427,7 +427,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -439,13 +439,13 @@
             "dev": true
         },
         "circuit-fuses": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/circuit-fuses/-/circuit-fuses-4.0.3.tgz",
-            "integrity": "sha512-txn3BUQWpYHoHPlghTye/eenlCof0/MR+z/t2h5AUE+6b5JEd4F3l5Ae83ZLT10bQO0L3qq65LI94E+Vh5YBjA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/circuit-fuses/-/circuit-fuses-4.0.4.tgz",
+            "integrity": "sha512-nykes91LpmSVX/yD0vW495pHV0qrjVpLanEnixjaIbK0ya+h17gmvVFyu6ojlkGt+oafyOPBMjOUER5hEjLR+A==",
             "requires": {
-                "request": "^2.73.0",
-                "retry-function": "^2.0.0",
-                "screwdriver-node-circuitbreaker": "^1.0.0"
+                "request": "2.88.0",
+                "retry-function": "2.1.0",
+                "screwdriver-node-circuitbreaker": "1.1.2"
             }
         },
         "circular-json": {
@@ -460,7 +460,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -495,7 +495,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -515,10 +515,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "contains-path": {
@@ -543,15 +543,24 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
+        "cron-parser": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.7.3.tgz",
+            "integrity": "sha512-t9Kc7HWBWPndBzvbdQ1YG9rpPRB37Tb/tTviziUOh1qs3TARGh3b1p+tnkOHNe1K5iI3oheBPgLqwotMM7+lpg==",
+            "requires": {
+                "is-nan": "1.2.1",
+                "moment-timezone": "0.5.23"
+            }
+        },
         "cross-spawn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
             }
         },
         "dashdash": {
@@ -559,7 +568,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "debug": {
@@ -593,19 +602,27 @@
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "1.0.12"
+            }
+        },
         "del": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "^5.0.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
             }
         },
         "delayed-stream": {
@@ -619,7 +636,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "diff": {
@@ -634,7 +651,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2"
+                "esutils": "2.0.2"
             }
         },
         "ecc-jsbn": {
@@ -642,8 +659,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "ecdsa-sig-formatter": {
@@ -651,7 +668,7 @@
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
             "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "error-ex": {
@@ -659,7 +676,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "escape-string-regexp": {
@@ -674,44 +691,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
-                "babel-code-frame": "^6.22.0",
-                "chalk": "^2.1.0",
-                "concat-stream": "^1.6.0",
-                "cross-spawn": "^5.1.0",
-                "debug": "^3.1.0",
-                "doctrine": "^2.1.0",
-                "eslint-scope": "^3.7.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^3.5.4",
-                "esquery": "^1.0.0",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.0.1",
-                "ignore": "^3.3.3",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^3.0.6",
-                "is-resolvable": "^1.0.0",
-                "js-yaml": "^3.9.1",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
-                "progress": "^2.0.0",
-                "regexpp": "^1.0.1",
-                "require-uncached": "^1.0.3",
-                "semver": "^5.3.0",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "~2.0.1",
+                "ajv": "5.3.0",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.4.1",
+                "concat-stream": "1.6.2",
+                "cross-spawn": "5.1.0",
+                "debug": "3.1.0",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "11.7.0",
+                "ignore": "3.3.10",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.12.1",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "regexpp": "1.1.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.5.0",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
                 "table": "4.0.2",
-                "text-table": "~0.2.0"
+                "text-table": "0.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -731,7 +748,7 @@
             "integrity": "sha1-hwOxGr48iKx+wrdFt/31LgCuaAo=",
             "dev": true,
             "requires": {
-                "eslint-restricted-globals": "^0.1.1"
+                "eslint-restricted-globals": "0.1.1"
             }
         },
         "eslint-config-screwdriver": {
@@ -740,9 +757,9 @@
             "integrity": "sha512-1uACYe4jFUew5hjdnH313+VQW/uDRxdS+1D8aEaYSQh9n0Wm5wO09WPY6EvPdS/vKFObBv6DiTr5zT6rtuEPZQ==",
             "dev": true,
             "requires": {
-                "eslint": "^4.3.0",
-                "eslint-config-airbnb-base": "^11.3.1",
-                "eslint-plugin-import": "^2.7.0"
+                "eslint": "4.19.1",
+                "eslint-config-airbnb-base": "11.3.2",
+                "eslint-plugin-import": "2.16.0"
             }
         },
         "eslint-import-resolver-node": {
@@ -750,34 +767,34 @@
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "requires": {
-                "debug": "^2.6.9",
-                "resolve": "^1.5.0"
+                "debug": "2.6.9",
+                "resolve": "1.5.0"
             }
         },
         "eslint-module-utils": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-            "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+            "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
             "requires": {
-                "debug": "^2.6.8",
-                "pkg-dir": "^1.0.0"
+                "debug": "2.6.9",
+                "pkg-dir": "2.0.0"
             }
         },
         "eslint-plugin-import": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-            "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
+            "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
             "requires": {
-                "contains-path": "^0.1.0",
-                "debug": "^2.6.8",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "^0.3.1",
-                "eslint-module-utils": "^2.2.0",
-                "has": "^1.0.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.3",
-                "read-pkg-up": "^2.0.0",
-                "resolve": "^1.6.0"
+                "eslint-import-resolver-node": "0.3.2",
+                "eslint-module-utils": "2.3.0",
+                "has": "1.0.3",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "2.0.0",
+                "resolve": "1.10.0"
             },
             "dependencies": {
                 "doctrine": {
@@ -785,16 +802,21 @@
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "isarray": "^1.0.0"
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
                     }
                 },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+                    "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+                },
                 "resolve": {
-                    "version": "1.8.1",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-                    "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+                    "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.6"
                     }
                 }
             }
@@ -811,8 +833,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             }
         },
         "eslint-visitor-keys": {
@@ -827,8 +849,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "5.7.1",
+                "acorn-jsx": "3.0.1"
             }
         },
         "esprima": {
@@ -842,7 +864,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.0.0"
+                "estraverse": "4.2.0"
             }
         },
         "esrecurse": {
@@ -851,7 +873,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             }
         },
         "estraverse": {
@@ -876,9 +898,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.23",
+                "tmp": "0.0.33"
             }
         },
         "extsprintf": {
@@ -909,7 +931,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "file-entry-cache": {
@@ -918,17 +940,16 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "^1.2.1",
-                "object-assign": "^4.0.1"
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
             }
         },
         "find-up": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "locate-path": "2.0.0"
             }
         },
         "flat-cache": {
@@ -937,10 +958,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "^0.3.1",
-                "del": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "write": "^0.2.1"
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
             }
         },
         "forever-agent": {
@@ -953,9 +974,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.21"
             }
         },
         "fs.realpath": {
@@ -967,7 +988,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -980,7 +1001,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -989,12 +1010,12 @@
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "globals": {
@@ -1009,12 +1030,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "graceful-fs": {
@@ -1038,8 +1059,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.6.2",
+                "har-schema": "2.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -1047,10 +1068,10 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
                     "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -1070,7 +1091,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -1079,7 +1100,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -1105,8 +1126,8 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.1"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "hosted-git-info": {
@@ -1119,9 +1140,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.16.0"
             }
         },
         "iconv-lite": {
@@ -1130,7 +1151,7 @@
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "dev": true,
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "ignore": {
@@ -1151,8 +1172,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -1167,20 +1188,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.0.4",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.11",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rx-lite": "^4.0.8",
-                "rx-lite-aggregates": "^4.0.8",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             }
         },
         "interpret": {
@@ -1195,7 +1216,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "is-arrayish": {
@@ -1208,7 +1229,7 @@
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-finite": {
@@ -1217,7 +1238,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-fullwidth-code-point": {
@@ -1225,6 +1246,14 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
+        },
+        "is-nan": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+            "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+            "requires": {
+                "define-properties": "1.1.3"
+            }
         },
         "is-path-cwd": {
             "version": "1.0.0",
@@ -1238,7 +1267,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "^1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
@@ -1247,7 +1276,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-promise": {
@@ -1273,18 +1302,11 @@
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isemail": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
-            "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+            "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
             "requires": {
-                "punycode": "2.x.x"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-                }
+                "punycode": "2.1.1"
             }
         },
         "isexe": {
@@ -1304,22 +1326,22 @@
             "integrity": "sha1-XqgafbtljPxyP/ucEhgxYihIQn8=",
             "dev": true,
             "requires": {
-                "mocha": "^4.0.0",
-                "npm-which": "^3.0.0",
-                "nyc": "^11.0.0",
-                "shell-escape": "^0.2.0",
-                "shelljs": "^0.7.5",
+                "mocha": "4.1.0",
+                "npm-which": "3.0.1",
+                "nyc": "11.9.0",
+                "shell-escape": "0.2.0",
+                "shelljs": "0.7.8",
                 "spec-xunit-file": "0.0.1-3"
             }
         },
         "joi": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
-            "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+            "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
             "requires": {
-                "hoek": "5.x.x",
-                "isemail": "3.x.x",
-                "topo": "3.x.x"
+                "hoek": "5.0.4",
+                "isemail": "3.2.0",
+                "topo": "3.0.3"
             }
         },
         "js-tokens": {
@@ -1333,8 +1355,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
             "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -1381,15 +1403,15 @@
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
             "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
             "requires": {
-                "jws": "^3.1.5",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.1.1"
+                "jws": "3.2.1",
+                "lodash.includes": "4.3.0",
+                "lodash.isboolean": "3.0.3",
+                "lodash.isinteger": "4.0.4",
+                "lodash.isnumber": "3.0.3",
+                "lodash.isplainobject": "4.0.6",
+                "lodash.isstring": "4.0.1",
+                "lodash.once": "4.1.1",
+                "ms": "2.1.1"
             },
             "dependencies": {
                 "ms": {
@@ -1417,22 +1439,22 @@
             "dev": true
         },
         "jwa": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-            "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
+            "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.10",
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "jws": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-            "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+            "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
             "requires": {
-                "jwa": "^1.1.5",
-                "safe-buffer": "^5.0.1"
+                "jwa": "1.2.0",
+                "safe-buffer": "5.1.1"
             }
         },
         "levn": {
@@ -1441,8 +1463,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "load-json-file": {
@@ -1450,10 +1472,10 @@
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
             }
         },
         "locate-path": {
@@ -1461,15 +1483,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-            },
-            "dependencies": {
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-                }
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -1530,7 +1545,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "lru-cache": {
@@ -1539,8 +1554,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "mime-db": {
@@ -1553,7 +1568,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.37.0"
             }
         },
         "mimic-fn": {
@@ -1567,7 +1582,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
             }
         },
         "minimist": {
@@ -1624,7 +1639,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                     }
                 }
             }
@@ -1634,6 +1649,19 @@
             "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
             "integrity": "sha1-WwrvH/Vk8PgTlEXhZVNseQlxNHA=",
             "dev": true
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        },
+        "moment-timezone": {
+            "version": "0.5.23",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+            "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+            "requires": {
+                "moment": "2.24.0"
+            }
         },
         "ms": {
             "version": "2.0.0",
@@ -1658,22 +1686,22 @@
             "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "^2.0.0",
-                "just-extend": "^1.1.27",
-                "lolex": "^2.3.2",
-                "path-to-regexp": "^1.7.0",
-                "text-encoding": "^0.6.4"
+                "@sinonjs/formatio": "2.0.0",
+                "just-extend": "1.1.27",
+                "lolex": "2.7.1",
+                "path-to-regexp": "1.7.0",
+                "text-encoding": "0.6.4"
             }
         },
         "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
+            "integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.7.1",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.4"
             }
         },
         "npm-path": {
@@ -1682,7 +1710,7 @@
             "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
             "dev": true,
             "requires": {
-                "which": "^1.2.10"
+                "which": "1.3.0"
             }
         },
         "npm-which": {
@@ -1691,9 +1719,9 @@
             "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
             "dev": true,
             "requires": {
-                "commander": "^2.9.0",
-                "npm-path": "^2.0.2",
-                "which": "^1.2.10"
+                "commander": "2.11.0",
+                "npm-path": "2.0.4",
+                "which": "1.3.0"
             }
         },
         "number-is-nan": {
@@ -1708,33 +1736,33 @@
             "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "arrify": "^1.0.1",
-                "caching-transform": "^1.0.0",
-                "convert-source-map": "^1.5.1",
-                "debug-log": "^1.0.1",
-                "default-require-extensions": "^1.0.0",
-                "find-cache-dir": "^0.1.1",
-                "find-up": "^2.1.0",
-                "foreground-child": "^1.5.3",
-                "glob": "^7.0.6",
-                "istanbul-lib-coverage": "^1.1.2",
-                "istanbul-lib-hook": "^1.1.0",
-                "istanbul-lib-instrument": "^1.10.0",
-                "istanbul-lib-report": "^1.1.3",
-                "istanbul-lib-source-maps": "^1.2.3",
-                "istanbul-reports": "^1.4.0",
-                "md5-hex": "^1.2.0",
-                "merge-source-map": "^1.1.0",
-                "micromatch": "^3.1.10",
-                "mkdirp": "^0.5.0",
-                "resolve-from": "^2.0.0",
-                "rimraf": "^2.6.2",
-                "signal-exit": "^3.0.1",
-                "spawn-wrap": "^1.4.2",
-                "test-exclude": "^4.2.0",
+                "archy": "1.0.0",
+                "arrify": "1.0.1",
+                "caching-transform": "1.0.1",
+                "convert-source-map": "1.5.1",
+                "debug-log": "1.0.1",
+                "default-require-extensions": "1.0.0",
+                "find-cache-dir": "0.1.1",
+                "find-up": "2.1.0",
+                "foreground-child": "1.5.6",
+                "glob": "7.1.2",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-hook": "1.1.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "istanbul-lib-report": "1.1.3",
+                "istanbul-lib-source-maps": "1.2.3",
+                "istanbul-reports": "1.4.0",
+                "md5-hex": "1.3.0",
+                "merge-source-map": "1.1.0",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "resolve-from": "2.0.0",
+                "rimraf": "2.6.2",
+                "signal-exit": "3.0.2",
+                "spawn-wrap": "1.4.2",
+                "test-exclude": "4.2.1",
                 "yargs": "11.1.0",
-                "yargs-parser": "^8.0.0"
+                "yargs-parser": "8.1.0"
             },
             "dependencies": {
                 "align-text": {
@@ -1742,9 +1770,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2",
-                        "longest": "^1.0.1",
-                        "repeat-string": "^1.5.2"
+                        "kind-of": "3.2.2",
+                        "longest": "1.0.1",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "amdefine": {
@@ -1767,7 +1795,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "default-require-extensions": "^1.0.0"
+                        "default-require-extensions": "1.0.0"
                     }
                 },
                 "archy": {
@@ -1820,9 +1848,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "chalk": "^1.1.3",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^3.0.2"
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
                     }
                 },
                 "babel-generator": {
@@ -1830,14 +1858,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-messages": "^6.23.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "detect-indent": "^4.0.0",
-                        "jsesc": "^1.3.0",
-                        "lodash": "^4.17.4",
-                        "source-map": "^0.5.7",
-                        "trim-right": "^1.0.1"
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "detect-indent": "4.0.0",
+                        "jsesc": "1.3.0",
+                        "lodash": "4.17.10",
+                        "source-map": "0.5.7",
+                        "trim-right": "1.0.1"
                     }
                 },
                 "babel-messages": {
@@ -1845,7 +1873,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "^6.22.0"
+                        "babel-runtime": "6.26.0"
                     }
                 },
                 "babel-runtime": {
@@ -1853,8 +1881,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "core-js": "^2.4.0",
-                        "regenerator-runtime": "^0.11.0"
+                        "core-js": "2.5.6",
+                        "regenerator-runtime": "0.11.1"
                     }
                 },
                 "babel-template": {
@@ -1862,11 +1890,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "lodash": "^4.17.4"
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "lodash": "4.17.10"
                     }
                 },
                 "babel-traverse": {
@@ -1874,15 +1902,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-messages": "^6.23.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "debug": "^2.6.8",
-                        "globals": "^9.18.0",
-                        "invariant": "^2.2.2",
-                        "lodash": "^4.17.4"
+                        "babel-code-frame": "6.26.0",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "debug": "2.6.9",
+                        "globals": "9.18.0",
+                        "invariant": "2.2.4",
+                        "lodash": "4.17.10"
                     }
                 },
                 "babel-types": {
@@ -1890,10 +1918,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "^6.26.0",
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.4",
-                        "to-fast-properties": "^1.0.3"
+                        "babel-runtime": "6.26.0",
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.10",
+                        "to-fast-properties": "1.0.3"
                     }
                 },
                 "babylon": {
@@ -1911,13 +1939,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cache-base": "^1.0.1",
-                        "class-utils": "^0.3.5",
-                        "component-emitter": "^1.2.1",
-                        "define-property": "^1.0.0",
-                        "isobject": "^3.0.1",
-                        "mixin-deep": "^1.2.0",
-                        "pascalcase": "^0.1.1"
+                        "cache-base": "1.0.1",
+                        "class-utils": "0.3.6",
+                        "component-emitter": "1.2.1",
+                        "define-property": "1.0.0",
+                        "isobject": "3.0.1",
+                        "mixin-deep": "1.3.1",
+                        "pascalcase": "0.1.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1925,7 +1953,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -1933,7 +1961,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -1941,7 +1969,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -1949,9 +1977,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "isobject": {
@@ -1971,7 +1999,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1980,16 +2008,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1997,7 +2025,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -2012,15 +2040,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "collection-visit": "^1.0.0",
-                        "component-emitter": "^1.2.1",
-                        "get-value": "^2.0.6",
-                        "has-value": "^1.0.0",
-                        "isobject": "^3.0.1",
-                        "set-value": "^2.0.0",
-                        "to-object-path": "^0.3.0",
-                        "union-value": "^1.0.0",
-                        "unset-value": "^1.0.0"
+                        "collection-visit": "1.0.0",
+                        "component-emitter": "1.2.1",
+                        "get-value": "2.0.6",
+                        "has-value": "1.0.0",
+                        "isobject": "3.0.1",
+                        "set-value": "2.0.0",
+                        "to-object-path": "0.3.0",
+                        "union-value": "1.0.0",
+                        "unset-value": "1.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -2035,9 +2063,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-hex": "^1.2.0",
-                        "mkdirp": "^0.5.1",
-                        "write-file-atomic": "^1.1.4"
+                        "md5-hex": "1.3.0",
+                        "mkdirp": "0.5.1",
+                        "write-file-atomic": "1.3.4"
                     }
                 },
                 "camelcase": {
@@ -2052,8 +2080,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "^0.1.3",
-                        "lazy-cache": "^1.0.3"
+                        "align-text": "0.1.4",
+                        "lazy-cache": "1.0.4"
                     }
                 },
                 "chalk": {
@@ -2061,11 +2089,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "class-utils": {
@@ -2073,10 +2101,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-union": "^3.1.0",
-                        "define-property": "^0.2.5",
-                        "isobject": "^3.0.0",
-                        "static-extend": "^0.1.1"
+                        "arr-union": "3.1.0",
+                        "define-property": "0.2.5",
+                        "isobject": "3.0.1",
+                        "static-extend": "0.1.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -2084,7 +2112,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "isobject": {
@@ -2100,8 +2128,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
                         "wordwrap": "0.0.2"
                     },
                     "dependencies": {
@@ -2123,8 +2151,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "map-visit": "^1.0.0",
-                        "object-visit": "^1.0.0"
+                        "map-visit": "1.0.0",
+                        "object-visit": "1.0.1"
                     }
                 },
                 "commondir": {
@@ -2162,8 +2190,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "which": "1.3.0"
                     }
                 },
                 "debug": {
@@ -2194,7 +2222,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-bom": "^2.0.0"
+                        "strip-bom": "2.0.0"
                     }
                 },
                 "define-property": {
@@ -2202,8 +2230,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
+                        "is-descriptor": "1.0.2",
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "is-accessor-descriptor": {
@@ -2211,7 +2239,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -2219,7 +2247,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -2227,9 +2255,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "isobject": {
@@ -2249,7 +2277,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "repeating": "^2.0.0"
+                        "repeating": "2.0.1"
                     }
                 },
                 "error-ex": {
@@ -2257,7 +2285,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-arrayish": "^0.2.1"
+                        "is-arrayish": "0.2.1"
                     }
                 },
                 "escape-string-regexp": {
@@ -2275,13 +2303,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -2289,9 +2317,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "^4.0.1",
-                                "shebang-command": "^1.2.0",
-                                "which": "^1.2.9"
+                                "lru-cache": "4.1.3",
+                                "shebang-command": "1.2.0",
+                                "which": "1.3.0"
                             }
                         }
                     }
@@ -2301,13 +2329,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -2315,7 +2343,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -2323,7 +2351,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -2333,8 +2361,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -2342,7 +2370,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "^2.0.4"
+                                "is-plain-object": "2.0.4"
                             }
                         }
                     }
@@ -2352,14 +2380,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -2367,7 +2395,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -2375,7 +2403,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -2383,7 +2411,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -2391,7 +2419,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -2399,9 +2427,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "kind-of": {
@@ -2416,10 +2444,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -2427,7 +2455,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -2437,9 +2465,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "commondir": "^1.0.1",
-                        "mkdirp": "^0.5.1",
-                        "pkg-dir": "^1.0.0"
+                        "commondir": "1.0.1",
+                        "mkdirp": "0.5.1",
+                        "pkg-dir": "1.0.0"
                     }
                 },
                 "find-up": {
@@ -2447,7 +2475,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "for-in": {
@@ -2460,8 +2488,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^4",
-                        "signal-exit": "^3.0.0"
+                        "cross-spawn": "4.0.2",
+                        "signal-exit": "3.0.2"
                     }
                 },
                 "fragment-cache": {
@@ -2469,7 +2497,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "map-cache": "^0.2.2"
+                        "map-cache": "0.2.2"
                     }
                 },
                 "fs.realpath": {
@@ -2497,12 +2525,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "globals": {
@@ -2520,10 +2548,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "^1.4.0",
-                        "optimist": "^0.6.1",
-                        "source-map": "^0.4.4",
-                        "uglify-js": "^2.6"
+                        "async": "1.5.2",
+                        "optimist": "0.6.1",
+                        "source-map": "0.4.4",
+                        "uglify-js": "2.8.29"
                     },
                     "dependencies": {
                         "source-map": {
@@ -2531,7 +2559,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "amdefine": ">=0.0.4"
+                                "amdefine": "1.0.1"
                             }
                         }
                     }
@@ -2541,7 +2569,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "has-flag": {
@@ -2554,9 +2582,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.6",
-                        "has-values": "^1.0.0",
-                        "isobject": "^3.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "1.0.0",
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -2571,8 +2599,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^3.0.0",
-                        "kind-of": "^4.0.0"
+                        "is-number": "3.0.0",
+                        "kind-of": "4.0.0"
                     },
                     "dependencies": {
                         "is-number": {
@@ -2580,7 +2608,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -2588,7 +2616,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -2598,7 +2626,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -2618,8 +2646,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -2632,7 +2660,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "loose-envify": "^1.0.0"
+                        "loose-envify": "1.3.1"
                     }
                 },
                 "invert-kv": {
@@ -2645,7 +2673,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-arrayish": {
@@ -2663,7 +2691,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtin-modules": "^1.0.0"
+                        "builtin-modules": "1.1.1"
                     }
                 },
                 "is-data-descriptor": {
@@ -2671,7 +2699,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-descriptor": {
@@ -2679,9 +2707,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2701,7 +2729,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -2714,7 +2742,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-odd": {
@@ -2722,7 +2750,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^4.0.0"
+                        "is-number": "4.0.0"
                     },
                     "dependencies": {
                         "is-number": {
@@ -2737,7 +2765,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -2787,7 +2815,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "append-transform": "^0.4.0"
+                        "append-transform": "0.4.0"
                     }
                 },
                 "istanbul-lib-instrument": {
@@ -2795,13 +2823,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-generator": "^6.18.0",
-                        "babel-template": "^6.16.0",
-                        "babel-traverse": "^6.18.0",
-                        "babel-types": "^6.18.0",
-                        "babylon": "^6.18.0",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "semver": "^5.3.0"
+                        "babel-generator": "6.26.1",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "semver": "5.5.0"
                     }
                 },
                 "istanbul-lib-report": {
@@ -2809,10 +2837,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "^1.1.2",
-                        "mkdirp": "^0.5.1",
-                        "path-parse": "^1.0.5",
-                        "supports-color": "^3.1.2"
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "path-parse": "1.0.5",
+                        "supports-color": "3.2.3"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -2820,7 +2848,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "has-flag": "^1.0.0"
+                                "has-flag": "1.0.0"
                             }
                         }
                     }
@@ -2830,11 +2858,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^3.1.0",
-                        "istanbul-lib-coverage": "^1.1.2",
-                        "mkdirp": "^0.5.1",
-                        "rimraf": "^2.6.1",
-                        "source-map": "^0.5.3"
+                        "debug": "3.1.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2",
+                        "source-map": "0.5.7"
                     },
                     "dependencies": {
                         "debug": {
@@ -2852,7 +2880,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "^4.0.3"
+                        "handlebars": "4.0.11"
                     }
                 },
                 "js-tokens": {
@@ -2870,7 +2898,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "lazy-cache": {
@@ -2884,7 +2912,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -2892,11 +2920,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
                     }
                 },
                 "locate-path": {
@@ -2904,8 +2932,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     },
                     "dependencies": {
                         "path-exists": {
@@ -2930,7 +2958,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "js-tokens": "^3.0.0"
+                        "js-tokens": "3.0.2"
                     }
                 },
                 "lru-cache": {
@@ -2938,8 +2966,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 },
                 "map-cache": {
@@ -2952,7 +2980,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "object-visit": "^1.0.0"
+                        "object-visit": "1.0.1"
                     }
                 },
                 "md5-hex": {
@@ -2960,7 +2988,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "^0.1.1"
+                        "md5-o-matic": "0.1.1"
                     }
                 },
                 "md5-o-matic": {
@@ -2973,7 +3001,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.2.0"
                     }
                 },
                 "merge-source-map": {
@@ -2981,7 +3009,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "source-map": "^0.6.1"
+                        "source-map": "0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -2996,19 +3024,19 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3028,7 +3056,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -3041,8 +3069,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.2",
-                        "is-extendable": "^1.0.1"
+                        "for-in": "1.0.2",
+                        "is-extendable": "1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -3050,7 +3078,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "^2.0.4"
+                                "is-plain-object": "2.0.4"
                             }
                         }
                     }
@@ -3073,18 +3101,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "fragment-cache": "^0.2.1",
-                        "is-odd": "^2.0.0",
-                        "is-windows": "^1.0.2",
-                        "kind-of": "^6.0.2",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "fragment-cache": "0.2.1",
+                        "is-odd": "2.0.0",
+                        "is-windows": "1.0.2",
+                        "kind-of": "6.0.2",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "arr-diff": {
@@ -3109,10 +3137,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.6.0",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.5.0",
+                        "validate-npm-package-license": "3.0.3"
                     }
                 },
                 "npm-run-path": {
@@ -3120,7 +3148,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-key": "^2.0.0"
+                        "path-key": "2.0.1"
                     }
                 },
                 "number-is-nan": {
@@ -3138,9 +3166,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "copy-descriptor": "^0.1.0",
-                        "define-property": "^0.2.5",
-                        "kind-of": "^3.0.3"
+                        "copy-descriptor": "0.1.1",
+                        "define-property": "0.2.5",
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -3148,7 +3176,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         }
                     }
@@ -3158,7 +3186,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.0"
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -3173,7 +3201,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "isobject": {
@@ -3188,7 +3216,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "optimist": {
@@ -3196,8 +3224,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
+                        "minimist": "0.0.8",
+                        "wordwrap": "0.0.3"
                     }
                 },
                 "os-homedir": {
@@ -3210,9 +3238,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                     }
                 },
                 "p-finally": {
@@ -3225,7 +3253,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -3233,7 +3261,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.2.0"
                     }
                 },
                 "p-try": {
@@ -3246,7 +3274,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.2.0"
+                        "error-ex": "1.3.1"
                     }
                 },
                 "pascalcase": {
@@ -3259,7 +3287,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-is-absolute": {
@@ -3282,9 +3310,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "pify": {
@@ -3302,7 +3330,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie": "^2.0.0"
+                        "pinkie": "2.0.4"
                     }
                 },
                 "pkg-dir": {
@@ -3310,7 +3338,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0"
+                        "find-up": "1.1.2"
                     },
                     "dependencies": {
                         "find-up": {
@@ -3318,8 +3346,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
                             }
                         }
                     }
@@ -3339,9 +3367,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "1.1.0"
                     }
                 },
                 "read-pkg-up": {
@@ -3349,8 +3377,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -3358,8 +3386,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
                             }
                         }
                     }
@@ -3374,8 +3402,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^3.0.2",
-                        "safe-regex": "^1.1.0"
+                        "extend-shallow": "3.0.2",
+                        "safe-regex": "1.1.0"
                     }
                 },
                 "repeat-element": {
@@ -3393,7 +3421,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-finite": "^1.0.0"
+                        "is-finite": "1.0.2"
                     }
                 },
                 "require-directory": {
@@ -3427,7 +3455,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "^0.1.1"
+                        "align-text": "0.1.4"
                     }
                 },
                 "rimraf": {
@@ -3435,7 +3463,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-regex": {
@@ -3443,7 +3471,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ret": "~0.1.10"
+                        "ret": "0.1.15"
                     }
                 },
                 "semver": {
@@ -3461,10 +3489,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.3",
-                        "split-string": "^3.0.1"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "split-string": "3.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -3472,7 +3500,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -3482,7 +3510,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "^1.0.0"
+                        "shebang-regex": "1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -3505,14 +3533,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "base": "^0.11.1",
-                        "debug": "^2.2.0",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "map-cache": "^0.2.2",
-                        "source-map": "^0.5.6",
-                        "source-map-resolve": "^0.5.0",
-                        "use": "^3.1.0"
+                        "base": "0.11.2",
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "map-cache": "0.2.2",
+                        "source-map": "0.5.7",
+                        "source-map-resolve": "0.5.1",
+                        "use": "3.1.0"
                     },
                     "dependencies": {
                         "define-property": {
@@ -3520,7 +3548,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -3528,7 +3556,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -3538,9 +3566,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-property": "^1.0.0",
-                        "isobject": "^3.0.0",
-                        "snapdragon-util": "^3.0.1"
+                        "define-property": "1.0.0",
+                        "isobject": "3.0.1",
+                        "snapdragon-util": "3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -3548,7 +3576,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -3556,7 +3584,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -3564,7 +3592,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -3572,9 +3600,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "isobject": {
@@ -3594,7 +3622,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.2.0"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "source-map": {
@@ -3607,11 +3635,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "atob": "^2.0.0",
-                        "decode-uri-component": "^0.2.0",
-                        "resolve-url": "^0.2.1",
-                        "source-map-url": "^0.4.0",
-                        "urix": "^0.1.0"
+                        "atob": "2.1.1",
+                        "decode-uri-component": "0.2.0",
+                        "resolve-url": "0.2.1",
+                        "source-map-url": "0.4.0",
+                        "urix": "0.1.0"
                     }
                 },
                 "source-map-url": {
@@ -3624,12 +3652,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "foreground-child": "^1.5.6",
-                        "mkdirp": "^0.5.0",
-                        "os-homedir": "^1.0.1",
-                        "rimraf": "^2.6.2",
-                        "signal-exit": "^3.0.2",
-                        "which": "^1.3.0"
+                        "foreground-child": "1.5.6",
+                        "mkdirp": "0.5.1",
+                        "os-homedir": "1.0.2",
+                        "rimraf": "2.6.2",
+                        "signal-exit": "3.0.2",
+                        "which": "1.3.0"
                     }
                 },
                 "spdx-correct": {
@@ -3637,8 +3665,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-expression-parse": "^3.0.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-expression-parse": "3.0.0",
+                        "spdx-license-ids": "3.0.0"
                     }
                 },
                 "spdx-exceptions": {
@@ -3651,8 +3679,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-exceptions": "^2.1.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-exceptions": "2.1.0",
+                        "spdx-license-ids": "3.0.0"
                     }
                 },
                 "spdx-license-ids": {
@@ -3665,7 +3693,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^3.0.0"
+                        "extend-shallow": "3.0.2"
                     }
                 },
                 "static-extend": {
@@ -3673,8 +3701,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-property": "^0.2.5",
-                        "object-copy": "^0.1.0"
+                        "define-property": "0.2.5",
+                        "object-copy": "0.1.0"
                     },
                     "dependencies": {
                         "define-property": {
@@ -3682,7 +3710,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         }
                     }
@@ -3692,8 +3720,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -3706,7 +3734,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -3716,7 +3744,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-bom": {
@@ -3724,7 +3752,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                     }
                 },
                 "strip-eof": {
@@ -3742,11 +3770,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arrify": "^1.0.1",
-                        "micromatch": "^3.1.8",
-                        "object-assign": "^4.1.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-main-filename": "^1.0.1"
+                        "arrify": "1.0.1",
+                        "micromatch": "3.1.10",
+                        "object-assign": "4.1.1",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1"
                     },
                     "dependencies": {
                         "arr-diff": {
@@ -3764,16 +3792,16 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "arr-flatten": "^1.1.0",
-                                "array-unique": "^0.3.2",
-                                "extend-shallow": "^2.0.1",
-                                "fill-range": "^4.0.0",
-                                "isobject": "^3.0.1",
-                                "repeat-element": "^1.1.2",
-                                "snapdragon": "^0.8.1",
-                                "snapdragon-node": "^2.0.1",
-                                "split-string": "^3.0.2",
-                                "to-regex": "^3.0.1"
+                                "arr-flatten": "1.1.0",
+                                "array-unique": "0.3.2",
+                                "extend-shallow": "2.0.1",
+                                "fill-range": "4.0.0",
+                                "isobject": "3.0.1",
+                                "repeat-element": "1.1.2",
+                                "snapdragon": "0.8.2",
+                                "snapdragon-node": "2.1.1",
+                                "split-string": "3.1.0",
+                                "to-regex": "3.0.2"
                             },
                             "dependencies": {
                                 "extend-shallow": {
@@ -3781,7 +3809,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 }
                             }
@@ -3791,13 +3819,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "debug": "^2.3.3",
-                                "define-property": "^0.2.5",
-                                "extend-shallow": "^2.0.1",
-                                "posix-character-classes": "^0.1.0",
-                                "regex-not": "^1.0.0",
-                                "snapdragon": "^0.8.1",
-                                "to-regex": "^3.0.1"
+                                "debug": "2.6.9",
+                                "define-property": "0.2.5",
+                                "extend-shallow": "2.0.1",
+                                "posix-character-classes": "0.1.1",
+                                "regex-not": "1.0.2",
+                                "snapdragon": "0.8.2",
+                                "to-regex": "3.0.2"
                             },
                             "dependencies": {
                                 "define-property": {
@@ -3805,7 +3833,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-descriptor": "^0.1.0"
+                                        "is-descriptor": "0.1.6"
                                     }
                                 },
                                 "extend-shallow": {
@@ -3813,7 +3841,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 },
                                 "is-accessor-descriptor": {
@@ -3821,7 +3849,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "kind-of": "^3.0.2"
+                                        "kind-of": "3.2.2"
                                     },
                                     "dependencies": {
                                         "kind-of": {
@@ -3829,7 +3857,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "is-buffer": "^1.1.5"
+                                                "is-buffer": "1.1.6"
                                             }
                                         }
                                     }
@@ -3839,7 +3867,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "kind-of": "^3.0.2"
+                                        "kind-of": "3.2.2"
                                     },
                                     "dependencies": {
                                         "kind-of": {
@@ -3847,7 +3875,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "is-buffer": "^1.1.5"
+                                                "is-buffer": "1.1.6"
                                             }
                                         }
                                     }
@@ -3857,9 +3885,9 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-accessor-descriptor": "^0.1.6",
-                                        "is-data-descriptor": "^0.1.4",
-                                        "kind-of": "^5.0.0"
+                                        "is-accessor-descriptor": "0.1.6",
+                                        "is-data-descriptor": "0.1.4",
+                                        "kind-of": "5.1.0"
                                     }
                                 },
                                 "kind-of": {
@@ -3874,14 +3902,14 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "array-unique": "^0.3.2",
-                                "define-property": "^1.0.0",
-                                "expand-brackets": "^2.1.4",
-                                "extend-shallow": "^2.0.1",
-                                "fragment-cache": "^0.2.1",
-                                "regex-not": "^1.0.0",
-                                "snapdragon": "^0.8.1",
-                                "to-regex": "^3.0.1"
+                                "array-unique": "0.3.2",
+                                "define-property": "1.0.0",
+                                "expand-brackets": "2.1.4",
+                                "extend-shallow": "2.0.1",
+                                "fragment-cache": "0.2.1",
+                                "regex-not": "1.0.2",
+                                "snapdragon": "0.8.2",
+                                "to-regex": "3.0.2"
                             },
                             "dependencies": {
                                 "define-property": {
@@ -3889,7 +3917,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-descriptor": "^1.0.0"
+                                        "is-descriptor": "1.0.2"
                                     }
                                 },
                                 "extend-shallow": {
@@ -3897,7 +3925,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 }
                             }
@@ -3907,10 +3935,10 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "extend-shallow": "^2.0.1",
-                                "is-number": "^3.0.0",
-                                "repeat-string": "^1.6.1",
-                                "to-regex-range": "^2.1.0"
+                                "extend-shallow": "2.0.1",
+                                "is-number": "3.0.0",
+                                "repeat-string": "1.6.1",
+                                "to-regex-range": "2.1.1"
                             },
                             "dependencies": {
                                 "extend-shallow": {
@@ -3918,7 +3946,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-extendable": "^0.1.0"
+                                        "is-extendable": "0.1.1"
                                     }
                                 }
                             }
@@ -3928,7 +3956,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-data-descriptor": {
@@ -3936,7 +3964,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^6.0.0"
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-descriptor": {
@@ -3944,9 +3972,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^1.0.0",
-                                "is-data-descriptor": "^1.0.0",
-                                "kind-of": "^6.0.2"
+                                "is-accessor-descriptor": "1.0.0",
+                                "is-data-descriptor": "1.0.0",
+                                "kind-of": "6.0.2"
                             }
                         },
                         "is-number": {
@@ -3954,7 +3982,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -3962,7 +3990,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -3982,19 +4010,19 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "arr-diff": "^4.0.0",
-                                "array-unique": "^0.3.2",
-                                "braces": "^2.3.1",
-                                "define-property": "^2.0.2",
-                                "extend-shallow": "^3.0.2",
-                                "extglob": "^2.0.4",
-                                "fragment-cache": "^0.2.1",
-                                "kind-of": "^6.0.2",
-                                "nanomatch": "^1.2.9",
-                                "object.pick": "^1.3.0",
-                                "regex-not": "^1.0.0",
-                                "snapdragon": "^0.8.1",
-                                "to-regex": "^3.0.2"
+                                "arr-diff": "4.0.0",
+                                "array-unique": "0.3.2",
+                                "braces": "2.3.2",
+                                "define-property": "2.0.2",
+                                "extend-shallow": "3.0.2",
+                                "extglob": "2.0.4",
+                                "fragment-cache": "0.2.1",
+                                "kind-of": "6.0.2",
+                                "nanomatch": "1.2.9",
+                                "object.pick": "1.3.0",
+                                "regex-not": "1.0.2",
+                                "snapdragon": "0.8.2",
+                                "to-regex": "3.0.2"
                             }
                         }
                     }
@@ -4009,7 +4037,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "to-regex": {
@@ -4017,10 +4045,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "regex-not": "^1.0.2",
-                        "safe-regex": "^1.1.0"
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "regex-not": "1.0.2",
+                        "safe-regex": "1.1.0"
                     }
                 },
                 "to-regex-range": {
@@ -4028,8 +4056,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1"
                     },
                     "dependencies": {
                         "is-number": {
@@ -4037,7 +4065,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             }
                         }
                     }
@@ -4053,9 +4081,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "source-map": "0.5.7",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -4064,9 +4092,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "camelcase": "^1.0.2",
-                                "cliui": "^2.1.0",
-                                "decamelize": "^1.0.0",
+                                "camelcase": "1.2.1",
+                                "cliui": "2.1.0",
+                                "decamelize": "1.2.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -4083,10 +4111,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-union": "^3.1.0",
-                        "get-value": "^2.0.6",
-                        "is-extendable": "^0.1.1",
-                        "set-value": "^0.4.3"
+                        "arr-union": "3.1.0",
+                        "get-value": "2.0.6",
+                        "is-extendable": "0.1.1",
+                        "set-value": "0.4.3"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4094,7 +4122,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "set-value": {
@@ -4102,10 +4130,10 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "extend-shallow": "^2.0.1",
-                                "is-extendable": "^0.1.1",
-                                "is-plain-object": "^2.0.1",
-                                "to-object-path": "^0.3.0"
+                                "extend-shallow": "2.0.1",
+                                "is-extendable": "0.1.1",
+                                "is-plain-object": "2.0.4",
+                                "to-object-path": "0.3.0"
                             }
                         }
                     }
@@ -4115,8 +4143,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-value": "^0.3.1",
-                        "isobject": "^3.0.0"
+                        "has-value": "0.3.1",
+                        "isobject": "3.0.1"
                     },
                     "dependencies": {
                         "has-value": {
@@ -4124,9 +4152,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "get-value": "^2.0.3",
-                                "has-values": "^0.1.4",
-                                "isobject": "^2.0.0"
+                                "get-value": "2.0.6",
+                                "has-values": "0.1.4",
+                                "isobject": "2.1.0"
                             },
                             "dependencies": {
                                 "isobject": {
@@ -4161,7 +4189,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.2"
+                        "kind-of": "6.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4176,8 +4204,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "^3.0.0",
-                        "spdx-expression-parse": "^3.0.0"
+                        "spdx-correct": "3.0.0",
+                        "spdx-expression-parse": "3.0.0"
                     }
                 },
                 "which": {
@@ -4185,7 +4213,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "^2.0.0"
+                        "isexe": "2.0.0"
                     }
                 },
                 "which-module": {
@@ -4209,8 +4237,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                     },
                     "dependencies": {
                         "is-fullwidth-code-point": {
@@ -4218,7 +4246,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                             }
                         },
                         "string-width": {
@@ -4226,9 +4254,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         }
                     }
@@ -4243,9 +4271,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "imurmurhash": "^0.1.4",
-                        "slide": "^1.1.5"
+                        "graceful-fs": "4.1.11",
+                        "imurmurhash": "0.1.4",
+                        "slide": "1.1.6"
                     }
                 },
                 "y18n": {
@@ -4263,18 +4291,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
+                        "cliui": "4.1.0",
+                        "decamelize": "1.2.0",
+                        "find-up": "2.1.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "9.0.2"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -4292,9 +4320,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "string-width": "^2.1.1",
-                                "strip-ansi": "^4.0.0",
-                                "wrap-ansi": "^2.0.0"
+                                "string-width": "2.1.1",
+                                "strip-ansi": "4.0.0",
+                                "wrap-ansi": "2.1.0"
                             }
                         },
                         "strip-ansi": {
@@ -4302,7 +4330,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         },
                         "yargs-parser": {
@@ -4310,7 +4338,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "camelcase": "^4.1.0"
+                                "camelcase": "4.1.0"
                             }
                         }
                     }
@@ -4320,7 +4348,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -4343,13 +4371,18 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
+        "object-keys": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -4358,7 +4391,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "optionator": {
@@ -4367,12 +4400,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "os-homedir": {
@@ -4392,7 +4425,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "1.0.0"
             }
         },
         "p-locate": {
@@ -4400,7 +4433,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.3.0"
             }
         },
         "p-try": {
@@ -4413,16 +4446,13 @@
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.2"
             }
         },
         "path-exists": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "requires": {
-                "pinkie-promise": "^2.0.0"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -4463,7 +4493,7 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
             "requires": {
-                "pify": "^2.0.0"
+                "pify": "2.3.0"
             }
         },
         "performance-now": {
@@ -4479,22 +4509,24 @@
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "pkg-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-            "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "requires": {
-                "find-up": "^1.0.0"
+                "find-up": "2.1.0"
             }
         },
         "pluralize": {
@@ -4573,9 +4605,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
             "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.2",
+                "path-type": "2.0.0"
             }
         },
         "read-pkg-up": {
@@ -4583,18 +4615,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
             "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-                    "requires": {
-                        "locate-path": "^2.0.0"
-                    }
-                }
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
             }
         },
         "readable-stream": {
@@ -4603,13 +4625,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "rechoir": {
@@ -4618,7 +4640,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "^1.1.6"
+                "resolve": "1.5.0"
             }
         },
         "regenerator-runtime": {
@@ -4639,7 +4661,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "^1.0.0"
+                "is-finite": "1.0.2"
             }
         },
         "request": {
@@ -4647,26 +4669,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.21",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "extend": {
@@ -4686,10 +4708,10 @@
             "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
             "integrity": "sha512-Lmh9qMvnQXADGAQxsXHP4rbgO6pffCfuR8XUBdP9aitJcLQJxhp7YZK4xAVYXnPJ5E52mwrfiKQtKonPL8xsmg==",
             "requires": {
-                "extend": "^3.0.0",
-                "lodash": "^4.15.0",
-                "request": "^2.74.0",
-                "when": "^3.7.7"
+                "extend": "3.0.1",
+                "lodash": "4.17.11",
+                "request": "2.88.0",
+                "when": "3.7.8"
             }
         },
         "require-uncached": {
@@ -4698,8 +4720,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "^0.1.0",
-                "resolve-from": "^1.0.0"
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
             }
         },
         "resolve": {
@@ -4707,7 +4729,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
             "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "resolve-from": {
@@ -4722,8 +4744,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "retry": {
@@ -4734,10 +4756,10 @@
         "retry-function": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/retry-function/-/retry-function-2.1.0.tgz",
-            "integrity": "sha1-DgespVCUwIA7E06QoCg0S/AOV/k=",
+            "integrity": "sha512-yl8mfFg9N9nx3r01lCqY9+6oR4k/4zbmr9Vxke9lL/DwXtdkOC3fs1nVlBx1+/LQbJCwGG4tlc13JUVHfV7hsQ==",
             "requires": {
-                "joi": "^13.0.1",
-                "retry": "^0.10.0"
+                "joi": "13.7.0",
+                "retry": "0.10.1"
             }
         },
         "rewire": {
@@ -4746,8 +4768,8 @@
             "integrity": "sha512-ejkkt3qYnsQ38ifc9llAAzuHiGM7kR8N5/mL3aHWgmWwet0OMFcmJB8aTsMV2PBHCWxNVTLCeRfBpEa8X2+1fw==",
             "dev": true,
             "requires": {
-                "babel-core": "^6.26.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.26.0"
+                "babel-core": "6.26.3",
+                "babel-plugin-transform-es2015-block-scoping": "6.26.0"
             }
         },
         "rimraf": {
@@ -4756,7 +4778,7 @@
             "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
             }
         },
         "run-async": {
@@ -4765,7 +4787,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "rx-lite": {
@@ -4780,7 +4802,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "*"
+                "rx-lite": "4.0.8"
             }
         },
         "safe-buffer": {
@@ -4800,21 +4822,22 @@
             "dev": true
         },
         "screwdriver-data-schema": {
-            "version": "18.38.0",
-            "resolved": "https://registry.npmjs.org/screwdriver-data-schema/-/screwdriver-data-schema-18.38.0.tgz",
-            "integrity": "sha512-6ncPaBhP0yvGgfYliOBss0EJ3/xQvUYXJvWaY2UuLhhrhzv2JW6qnmNAnlkGCU3P2941yb8QNY0W/FLTh9/R5Q==",
+            "version": "18.43.2",
+            "resolved": "https://registry.npmjs.org/screwdriver-data-schema/-/screwdriver-data-schema-18.43.2.tgz",
+            "integrity": "sha512-gnApC14Wn6tut/pFst5N1VHYoJ2dCVYhGhxslDkvn0DpRYbbvTVgefdxAN9tcTfJlfX8BomDJZKiBmlqo0/YUg==",
             "requires": {
-                "joi": "^13.5.2"
+                "cron-parser": "2.7.3",
+                "joi": "13.7.0"
             }
         },
         "screwdriver-executor-base": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/screwdriver-executor-base/-/screwdriver-executor-base-6.3.0.tgz",
-            "integrity": "sha512-kaJ31fUgbDlx+ALv2xcO9SOZ5Xpag0n7UaS75rsA7dWfnR03xKbaD1auIehHZgFRdnLB9Ew6ukbhoEDBT+cTww==",
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/screwdriver-executor-base/-/screwdriver-executor-base-6.3.2.tgz",
+            "integrity": "sha512-agFot3uI7a1feGwR6xGcZkmE/KE2jy5QCTiq5+rnrmpiH0x5iG7ooy9PuJwAQsH/1xY7FKmmPZexE39cgFle4w==",
             "requires": {
-                "joi": "^13.0.0",
-                "jsonwebtoken": "^8.2.2",
-                "screwdriver-data-schema": "^18.37.0"
+                "joi": "13.7.0",
+                "jsonwebtoken": "8.4.0",
+                "screwdriver-data-schema": "18.43.2"
             }
         },
         "screwdriver-node-circuitbreaker": {
@@ -4822,7 +4845,7 @@
             "resolved": "https://registry.npmjs.org/screwdriver-node-circuitbreaker/-/screwdriver-node-circuitbreaker-1.1.2.tgz",
             "integrity": "sha512-SpukSEkaEs0KvA/h5KRn4VSuDftbKeqn2ggUoH4cuXiYpf7ygynSBbQLIndXWlo4T6vNZkVZFMx8bO0qv4Z+IA==",
             "requires": {
-                "q": "^1.5.0"
+                "q": "1.5.1"
             }
         },
         "semver": {
@@ -4836,7 +4859,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -4857,9 +4880,9 @@
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
+                "glob": "7.1.2",
+                "interpret": "1.2.0",
+                "rechoir": "0.6.2"
             }
         },
         "signal-exit": {
@@ -4874,13 +4897,13 @@
             "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "^2.0.0",
-                "diff": "^3.5.0",
-                "lodash.get": "^4.4.2",
-                "lolex": "^2.4.2",
-                "nise": "^1.3.3",
-                "supports-color": "^5.4.0",
-                "type-detect": "^4.0.8"
+                "@sinonjs/formatio": "2.0.0",
+                "diff": "3.5.0",
+                "lodash.get": "4.4.2",
+                "lolex": "2.7.1",
+                "nise": "1.4.2",
+                "supports-color": "5.4.0",
+                "type-detect": "4.0.8"
             },
             "dependencies": {
                 "diff": {
@@ -4895,7 +4918,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "type-detect": {
@@ -4918,7 +4941,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0"
+                "is-fullwidth-code-point": "2.0.0"
             }
         },
         "source-map": {
@@ -4933,36 +4956,36 @@
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
             }
         },
         "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.3"
             }
         },
         "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.2.0",
+                "spdx-license-ids": "3.0.3"
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+            "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
         },
         "spec-xunit-file": {
             "version": "0.0.1-3",
@@ -4980,15 +5003,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
             "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "string-width": {
@@ -4997,8 +5020,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "string_decoder": {
@@ -5007,7 +5030,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
             }
         },
         "strip-ansi": {
@@ -5016,7 +5039,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5050,12 +5073,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.2.3",
-                "ajv-keywords": "^2.1.0",
-                "chalk": "^2.1.0",
-                "lodash": "^4.17.4",
+                "ajv": "5.3.0",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.4.1",
+                "lodash": "4.17.11",
                 "slice-ansi": "1.0.0",
-                "string-width": "^2.1.1"
+                "string-width": "2.1.1"
             }
         },
         "text-encoding": {
@@ -5087,7 +5110,7 @@
             "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-fast-properties": {
@@ -5097,11 +5120,18 @@
             "dev": true
         },
         "topo": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-            "integrity": "sha1-N+SMMw7+rHhFOOCs0+YspeIx/no=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+            "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
             "requires": {
-                "hoek": "5.x.x"
+                "hoek": "6.1.2"
+            },
+            "dependencies": {
+                "hoek": {
+                    "version": "6.1.2",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+                    "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+                }
             }
         },
         "tough-cookie": {
@@ -5109,8 +5139,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
+                "psl": "1.1.31",
+                "punycode": "1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -5131,7 +5161,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "tweetnacl": {
@@ -5145,7 +5175,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "type-detect": {
@@ -5165,7 +5195,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "util-deprecate": {
@@ -5184,8 +5214,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.1.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "verror": {
@@ -5193,9 +5223,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "when": {
@@ -5209,7 +5239,7 @@
             "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "wordwrap": {
@@ -5230,7 +5260,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1"
+                "mkdirp": "0.5.1"
             }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -50,15 +50,15 @@
         "sinon": "^5.0.10"
     },
     "dependencies": {
-        "circuit-fuses": "^4.0.3",
-        "eslint-plugin-import": "^2.14.0",
+        "circuit-fuses": "^4.0.4",
+        "eslint-plugin-import": "^2.16.0",
         "hoek": "^5.0.4",
         "js-yaml": "^3.12.1",
         "lodash": "^4.17.11",
         "randomstring": "^1.1.5",
         "requestretry": "^1.13.0",
-        "screwdriver-data-schema": "^18.38.0",
-        "screwdriver-executor-base": "^6.3.0",
+        "screwdriver-data-schema": "^18.43.2",
+        "screwdriver-executor-base": "^6.3.2",
         "tinytim": "^0.1.1"
     }
 }


### PR DESCRIPTION
- add disk speed annotation / node selector
- if annotation not specified, can go to any node. If annotation specified, will go to the desired node with proper resources 

Blocked by: https://github.com/screwdriver-cd/executor-base/pull/51
Related to: https://github.com/screwdriver-cd/screwdriver/issues/1463