### PR TITLE
feat: cache launcher dependencies. BREAKING CHANGE: pod config changes

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -61,7 +61,7 @@ spec:
   initContainers:
   - name: launcher
     image: {{launcher_image}}
-    command: ['/bin/sh', '-c', 'if ! [ -d /opt/launcher/hab ]; then cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -41,7 +41,8 @@ spec:
          "--build_id", "{{build_id}}",
          "--id_with_prefix", "{{build_id_with_prefix}}",
          "--build_token", "{{token}}",
-         "--build_timeout", "{{build_timeout}}"
+         "--build_timeout", "{{build_timeout}}",
+         "--launcher_version", "{{launcher_version}}"
           ]
     env:
     - name: PUSHGATEWAY_URL
@@ -60,7 +61,7 @@ spec:
   initContainers:
   - name: launcher
     image: {{launcher_image}}
-    command: command: ['/bin/sh', '-c', 'if ! [ -d /opt/launcher/hab/pkgs ]; then cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'if ! [ -d /opt/launcher/hab/pkgs ]; then cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab; else ls /opt/launcher; fi;']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher
@@ -74,5 +75,6 @@ spec:
         path: /opt/screwdriver
 
     - name: sdlauncher
+      type: DirectoryOrCreate
       hostPath:
         path: /opt/screwdriver/sdlauncher/{{launcher_version}}

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -61,7 +61,7 @@ spec:
   initContainers:
   - name: launcher
     image: {{launcher_image}}
-    command: ['/bin/sh', '-c', 'if ! [ -d /opt/launcher/hab/pkgs ]; then cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'if ! [ -d /opt/launcher/hab ]; then cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab; else ls /opt/launcher; fi;']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -60,7 +60,7 @@ spec:
   initContainers:
   - name: launcher
     image: {{launcher_image}}
-    command: ['/bin/sh', '-c', 'cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab']
+    command: command: ['/bin/sh', '-c', 'if ! [ -d /opt/launcher/hab/pkgs ]; then cp -a /opt/sd/* /opt/launcher && mkdir -p /opt/launcher/hab && cp -a /hab/* /opt/launcher/hab; else ls /opt/launcher; fi;']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher
@@ -75,4 +75,4 @@ spec:
 
     - name: sdlauncher
       hostPath:
-        path: /opt/screwdriver/{{build_id_with_prefix}}/sdlauncher
+        path: /opt/screwdriver/sdlauncher/{{launcher_version}}

--- a/index.js
+++ b/index.js
@@ -291,7 +291,7 @@ class K8sVMExecutor extends Executor {
                 pushgateway_url: hoek.reach(this.ecosystem, 'pushgatewayUrl', { default: '' }),
                 token,
                 launcher_image: `${this.launchImage}:${this.launchVersion}`,
-                launcher_veriosn: this.launchVersion,
+                launcher_version: this.launchVersion,
                 base_image: this.baseImage
             });
 

--- a/index.js
+++ b/index.js
@@ -291,6 +291,7 @@ class K8sVMExecutor extends Executor {
                 pushgateway_url: hoek.reach(this.ecosystem, 'pushgatewayUrl', { default: '' }),
                 token,
                 launcher_image: `${this.launchImage}:${this.launchVersion}`,
+                launcher_veriosn: this.launchVersion,
                 base_image: this.baseImage
             });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,6 +19,7 @@ metadata:
   name: {{build_id_with_prefix}}
   container: {{container}}
   launchImage: {{launcher_image}}
+  launchVersion: {{launcher_veriosn}}
 command:
 - "/opt/sd/launch {{api_uri}} {{store_uri}} {{token}} {{build_timeout}} {{build_id}}"
 spec:
@@ -457,7 +458,8 @@ describe('index', () => {
                         memory: 2048,
                         name: 'beta_15',
                         container: testContainer,
-                        launchImage: `${testLaunchImage}:${testLaunchVersion}`
+                        launchImage: `${testLaunchImage}:${testLaunchVersion}`,
+                        launchVersion: testLaunchVersion
                     },
                     spec: testPodSpec,
                     command: [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,7 +19,7 @@ metadata:
   name: {{build_id_with_prefix}}
   container: {{container}}
   launchImage: {{launcher_image}}
-  launchVersion: {{launcher_veriosn}}
+  launchVersion: {{launcher_version}}
 command:
 - "/opt/sd/launch {{api_uri}} {{store_uri}} {{token}} {{build_timeout}} {{build_id}}"
 spec:


### PR DESCRIPTION
Currently, for each build, it's doing cp for all the launcher dependencies to the host. But for builds using the same launcher version, all the dependencies will be the same.

This PR will make the first pod on a node to do the `cp`, the later pods coming to the pod will just enjoy the benefit of the cache.

For deployment, this need to go out with the latest executor-k8s-vm

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1489

