### PR TITLE
fix: add prestop hook to give log-service some buffer to finish uploa…

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -24,6 +24,10 @@ spec:
   - name: vm-launcher
     image: {{base_image}}
     imagePullPolicy: Always
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh","-c","sleep 30"]
     securityContext:
       privileged: true
     resources:


### PR DESCRIPTION
It is possible that the launcher finished and updated the build final status before log service finish uploading logs. Add sleep 30 secs in the preStop hook to give log-service some time before pod is terminated.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1676