### PR TITLE
fix: Allow any setting for disk space

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The class provides a couple options that are configurable in the instantiation o
 | config.kubernetes.resources.cpu.high | Number | 6 | Value for HIGH CPU (in cores) |
 | config.kubernetes.resources.cpu.low | Number | 2 | Value for LOW CPU (in cores) |
 | config.kubernetes.resources.cpu.micro | Number | 1 | Value for MICRO CPU (in cores) |
+| config.kubernetes.resources.disk.space | String | | Value for disk space label (e.g.: screwdriver.cd/disk) |
+| config.kubernetes.resources.disk.speed | String | | Value for disk speed label (e.g.: screwdriver.cd/diskSpeed) |
 
 ### Methods
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -658,7 +658,7 @@ describe('index', () => {
                     baseImage: 'hyperctl',
                     resources: {
                         disk: {
-                            high: 'screwdriver.cd/disk'
+                            space: 'screwdriver.cd/disk'
                         }
                     }
                 }


### PR DESCRIPTION
## Context

The cluster admin might want to add new disk space or speed settings but don't want to make code changes each time. 

## Objective

This PR will rename the disk space setting to something more generic (from `high` to `space`). Also will no longer check the user config value for the disk label(s).

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
