### PR TITLE
fix: Do not set disk toleration when annotation is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,14 +307,15 @@ class K8sVMExecutor extends Executor {
 
         if (this.diskLabel) {
             const diskConfig = (annotations[DISK_RESOURCE] || '').toLowerCase();
-            const diskSelectors = { [this.diskLabel]: diskConfig };
+            const diskSelectors = diskConfig ? { [this.diskLabel]: diskConfig } : {};
 
             hoek.merge(nodeSelectors, diskSelectors);
         }
 
         if (this.diskSpeedLabel) {
             const diskSpeedConfig = (annotations[DISK_SPEED_RESOURCE] || '').toLowerCase();
-            const diskSpeedSelectors = { [this.diskSpeedLabel]: diskSpeedConfig };
+            const diskSpeedSelectors = diskSpeedConfig ?
+                { [this.diskSpeedLabel]: diskSpeedConfig } : {};
 
             hoek.merge(nodeSelectors, diskSpeedSelectors);
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -674,6 +674,33 @@ describe('index', () => {
             });
         });
 
+        it('does not set disk toleration and node affinity when disk is not set', () => {
+            fakeStartConfig.annotations = {};
+            const spec = _.merge({}, testSpec, testPodSpec);
+            const options = _.assign({}, executorOptions, {
+                kubernetes: {
+                    nodeSelectors: { key: 'value' },
+                    token: 'api_key',
+                    host: 'kubernetes.default',
+                    baseImage: 'hyperctl',
+                    resources: {
+                        disk: {
+                            space: 'screwdriver.cd/disk'
+                        }
+                    }
+                }
+            });
+
+            executor = new Executor(options);
+            postConfig.body.spec = spec;
+            getConfig.retryStrategy = executor.podRetryStrategy;
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
+
         it('sets disk speed toleration and node affinity when diskSpeed is HIGH', () => {
             const spec = _.merge({}, testSpecWithDiskSpeed, testPodSpec);
             const options = _.assign({}, executorOptions, {
@@ -693,6 +720,33 @@ describe('index', () => {
             executor = new Executor(options);
             postConfig.body.spec = spec;
             fakeStartConfig.annotations = { 'screwdriver.cd/diskSpeed': 'high' };
+            getConfig.retryStrategy = executor.podRetryStrategy;
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
+
+        it('does not set disk speed toleration when disk speed is not set', () => {
+            fakeStartConfig.annotations = {};
+            const spec = _.merge({}, testSpec, testPodSpec);
+            const options = _.assign({}, executorOptions, {
+                kubernetes: {
+                    nodeSelectors: { key: 'value' },
+                    token: 'api_key',
+                    host: 'kubernetes.default',
+                    baseImage: 'hyperctl',
+                    resources: {
+                        disk: {
+                            speed: 'screwdriver.cd/diskspeed'
+                        }
+                    }
+                }
+            });
+
+            executor = new Executor(options);
+            postConfig.body.spec = spec;
             getConfig.retryStrategy = executor.podRetryStrategy;
 
             return executor.start(fakeStartConfig).then(() => {


### PR DESCRIPTION
## Context

By default, should not set disk space and speed tolerations and annotations in k8s when it is not configured in the annotation.

## Objective

This PR does not set disk info by default.

## References

Related to https://github.com/screwdriver-cd/executor-k8s-vm/pull/60

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
