### PR TITLE
feat(1830): k8s pod config changes to support cache to disk strategy

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -43,13 +43,13 @@ spec:
          "--store_uri", "{{store_uri}}",
          "--ui_uri", "{{ui_uri}}",
          "--build_id", "{{build_id}}",
+         "--job_id", "{{job_id}}",
+         "--event_id","{{event_id}}",
+         "--pipeline_id", "{{pipeline_id}}",
          "--id_with_prefix", "{{build_id_with_prefix}}",
          "--build_token", "{{token}}",
          "--build_timeout", "{{build_timeout}}",
          "--launcher_version", "{{launcher_version}}",
-         "--job_id", "{{job_id}}",
-         "--event_id","{{event_id}}",
-         "--pipeline_id", "{{pipeline_id}}",
          "--cache_path", "{{cache_path}}"
           ]
     env:

--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -50,6 +50,7 @@ spec:
          "--build_token", "{{token}}",
          "--build_timeout", "{{build_timeout}}",
          "--launcher_version", "{{launcher_version}}",
+         "--cache_strategy", "{{cache_strategy}}",
          "--cache_path", "{{cache_path}}"
           ]
     env:

--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -46,7 +46,11 @@ spec:
          "--id_with_prefix", "{{build_id_with_prefix}}",
          "--build_token", "{{token}}",
          "--build_timeout", "{{build_timeout}}",
-         "--launcher_version", "{{launcher_version}}"
+         "--launcher_version", "{{launcher_version}}",
+         "--job_id", "{{job_id}}",
+         "--event_id","{{event_id}}",
+         "--pipeline_id", "{{pipeline_id}}",
+         "--cache_path", "{{cache_path}}"
           ]
     env:
     - name: PUSHGATEWAY_URL
@@ -62,6 +66,8 @@ spec:
       name: sd-workspaces
     - mountPath: /opt/sd
       name: sdlauncher
+    - mountPath: /opt/sd/cache
+      name: sdcache
   initContainers:
   - name: launcher
     image: {{launcher_image}}
@@ -80,3 +86,15 @@ spec:
       type: DirectoryOrCreate
       hostPath:
         path: /opt/screwdriver/sdlauncher/{{launcher_version}}
+    - name: sdcache
+      type: DirectoryOrCreate
+      hostPath:
+        path: {{cache_path}}/pipelines/{{pipeline_id}}
+    - name: sdjobcache
+      type: DirectoryOrCreate
+      hostPath:
+        path: {{cache_path}}/pipelines/{{pipeline_id}}/jobs/{{job_id}}
+    - name: sdeventcache
+      type: DirectoryOrCreate
+      hostPath:
+        path: {{cache_path}}/pipelines/{{pipeline_id}}/events/{{event_id}}

--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -69,6 +69,7 @@ spec:
       name: sdlauncher
     - mountPath: /opt/sd/cache/pipeline
       name: sd-pipeline-cache
+      readOnly: {{volumeReadOnly}}
     - mountPath: /opt/sd/cache/job
       name: sd-job-cache
     - mountPath: /opt/sd/cache/event

--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -66,8 +66,12 @@ spec:
       name: sd-workspaces
     - mountPath: /opt/sd
       name: sdlauncher
-    - mountPath: /opt/sd/cache
-      name: sdcache
+    - mountPath: /opt/sd/cache/pipeline
+      name: sd-pipeline-cache
+    - mountPath: /opt/sd/cache/job
+      name: sd-job-cache
+    - mountPath: /opt/sd/cache/event
+      name: sd-event-cache
   initContainers:
   - name: launcher
     image: {{launcher_image}}
@@ -86,15 +90,15 @@ spec:
       type: DirectoryOrCreate
       hostPath:
         path: /opt/screwdriver/sdlauncher/{{launcher_version}}
-    - name: sdcache
+    - name: sd-pipeline-cache
       type: DirectoryOrCreate
       hostPath:
         path: {{cache_path}}/pipelines/{{pipeline_id}}
-    - name: sdjobcache
+    - name: sd-job-cache
       type: DirectoryOrCreate
       hostPath:
-        path: {{cache_path}}/pipelines/{{pipeline_id}}/jobs/{{job_id}}
-    - name: sdeventcache
+        path: {{cache_path}}/jobs/{{pipeline_id}}/{{job_id}}
+    - name: sd-event-cache
       type: DirectoryOrCreate
       hostPath:
-        path: {{cache_path}}/pipelines/{{pipeline_id}}/events/{{event_id}}
+        path: {{cache_path}}/events/{{pipeline_id}}/{{event_id}}

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -43,13 +43,13 @@ spec:
          "--store_uri", "{{store_uri}}",
          "--ui_uri", "{{ui_uri}}",
          "--build_id", "{{build_id}}",
+         "--job_id", "{{job_id}}",
+         "--event_id","{{event_id}}",
+         "--pipeline_id", "{{pipeline_id}}",
          "--id_with_prefix", "{{build_id_with_prefix}}",
          "--build_token", "{{token}}",
          "--build_timeout", "{{build_timeout}}",
          "--launcher_version", "{{launcher_version}}",
-         "--job_id", "{{job_id}}",
-         "--event_id","{{event_id}}",
-         "--pipeline_id", "{{pipeline_id}}",
          "--cache_path", "{{cache_path}}"
           ]
     env:

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -50,6 +50,7 @@ spec:
          "--build_token", "{{token}}",
          "--build_timeout", "{{build_timeout}}",
          "--launcher_version", "{{launcher_version}}",
+         "--cache_strategy", "{{cache_strategy}}",
          "--cache_path", "{{cache_path}}"
           ]
     env:

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -46,7 +46,11 @@ spec:
          "--id_with_prefix", "{{build_id_with_prefix}}",
          "--build_token", "{{token}}",
          "--build_timeout", "{{build_timeout}}",
-         "--launcher_version", "{{launcher_version}}"
+         "--launcher_version", "{{launcher_version}}",
+         "--job_id", "{{job_id}}",
+         "--event_id","{{event_id}}",
+         "--pipeline_id", "{{pipeline_id}}",
+         "--cache_path", "{{cache_path}}"
           ]
     env:
     - name: PUSHGATEWAY_URL

--- a/index.js
+++ b/index.js
@@ -241,7 +241,8 @@ class K8sVMExecutor extends Executor {
      * @param  {Object}   config                    A configuration object
      * @param  {Object}   [config.annotations]      Set of key value pairs
      * @param  {Integer}  config.buildId            ID for the build
-     * @param  {Integer}  config.id                 pipelineId for the build
+     * @param  {Integer}  config.pipeline.id        pipelineId for the build
+     * @param  {Integer}  config.jobId              jobId for the build
      * @param  {Integer}  config.eventId            eventId for the build
      * @param  {String}   config.container          Container for the build to run in
      * @param  {String}   config.token              JWT for the Build

--- a/index.js
+++ b/index.js
@@ -238,14 +238,14 @@ class K8sVMExecutor extends Executor {
     /**
      * Starts a k8s build
      * @method start
-     * @param  {Object}   config                    A configuration object
-     * @param  {Object}   [config.annotations]      Set of key value pairs
-     * @param  {Integer}  config.buildId            ID for the build
-     * @param  {Integer}  config.pipeline.id        pipelineId for the build
-     * @param  {Integer}  config.jobId              jobId for the build
-     * @param  {Integer}  config.eventId            eventId for the build
-     * @param  {String}   config.container          Container for the build to run in
-     * @param  {String}   config.token              JWT for the Build
+     * @param  {Object}   config                        A configuration object
+     * @param  {Object}   [config.annotations]          Set of key value pairs
+     * @param  {Integer}  config.buildId                ID for the build
+     * @param  {Integer}  config.meta.build.pipeline.id pipelineId for the build
+     * @param  {Integer}  config.jobId                  jobId for the build
+     * @param  {Integer}  config.eventId                eventId for the build
+     * @param  {String}   config.container              Container for the build to run in
+     * @param  {String}   config.token                  JWT for the Build
      * @return {Promise}
      */
     _start(config) {
@@ -261,7 +261,7 @@ class K8sVMExecutor extends Executor {
             LOW: this.lowCpu,
             MICRO: this.microCpu
         };
-        // set volume readonly for PRs
+        // set pipeline cache volume readonly for PRs
         const volumeReadOnly = jobName.slice(0, 3) === 'PR-';
 
         let cpu = (cpuConfig in cpuValues) ? cpuValues[cpuConfig] : cpuValues.LOW;

--- a/index.js
+++ b/index.js
@@ -301,6 +301,9 @@ class K8sVMExecutor extends Executor {
             pod_name: `${this.prefix}${buildId}-${random}`,
             build_id_with_prefix: `${this.prefix}${buildId}`,
             build_id: buildId,
+            job_id: jobId,
+            pipeline_id: pipelineId,
+            event_id: eventId,
             build_timeout: buildTimeout,
             container,
             api_uri: this.ecosystem.api,
@@ -311,9 +314,6 @@ class K8sVMExecutor extends Executor {
             launcher_image: `${this.launchImage}:${this.launchVersion}`,
             launcher_version: this.launchVersion,
             base_image: this.baseImage,
-            job_id: jobId,
-            pipeline_id: pipelineId,
-            event_id: eventId,
             cache_path: ''
         };
         let podTemplate;

--- a/index.js
+++ b/index.js
@@ -249,11 +249,7 @@ class K8sVMExecutor extends Executor {
      */
     _start(config) {
         const { buildId, jobId, eventId, container, token } = config;
-        let pipelineId = '';
-
-        if (config.pipeline) {
-            pipelineId = config.pipeline.id || '';
-        }
+        const pipelineId = hoek.reach(config, 'pipeline.id', { default: '' });
         const annotations = this.parseAnnotations(
             hoek.reach(config, 'annotations', { default: {} }));
         const cpuConfig = annotations[CPU_RESOURCE];

--- a/index.js
+++ b/index.js
@@ -314,11 +314,13 @@ class K8sVMExecutor extends Executor {
             launcher_image: `${this.launchImage}:${this.launchVersion}`,
             launcher_version: this.launchVersion,
             base_image: this.baseImage,
+            cache_strategy: '',
             cache_path: ''
         };
         let podTemplate;
 
         if (this.cache_path && this.cache_strategy === CACHE_STRATEGY) {
+            podSpec.cache_strategy = this.cache_strategy;
             podSpec.cache_path = this.cache_path;
             if (this.prefix) {
                 podSpec.cache_path = this.cache_path.concat('/').concat(this.prefix);

--- a/index.js
+++ b/index.js
@@ -320,6 +320,9 @@ class K8sVMExecutor extends Executor {
 
         if (this.cache_path && this.cache_strategy === CACHE_STRATEGY) {
             podSpec.cache_path = this.cache_path;
+            if (this.prefix) {
+                podSpec.cache_path = this.cache_path.concat('/').concat(this.prefix);
+            }
             podTemplate = tinytim.renderFile(
                 path.resolve(__dirname, './config/pod.cache2disk.yaml.tim'), podSpec);
         } else {

--- a/index.js
+++ b/index.js
@@ -250,7 +250,8 @@ class K8sVMExecutor extends Executor {
      */
     _start(config) {
         const { buildId, jobId, eventId, container, token } = config;
-        const pipelineId = hoek.reach(config, 'pipeline.id', { default: '' });
+        const pipelineId = hoek.reach(config, 'meta.build.pipelineId', { default: '' });
+        const jobName = hoek.reach(config, 'meta.build.jobName', { default: '' });
         const annotations = this.parseAnnotations(
             hoek.reach(config, 'annotations', { default: {} }));
         const cpuConfig = annotations[CPU_RESOURCE];
@@ -260,6 +261,9 @@ class K8sVMExecutor extends Executor {
             LOW: this.lowCpu,
             MICRO: this.microCpu
         };
+        // set volume readonly for PRs
+        const volumeReadOnly = jobName.slice(0, 3) === 'PR-';
+
         let cpu = (cpuConfig in cpuValues) ? cpuValues[cpuConfig] : cpuValues.LOW;
 
         // allow custom cpu value
@@ -312,7 +316,8 @@ class K8sVMExecutor extends Executor {
             launcher_version: this.launchVersion,
             base_image: this.baseImage,
             cache_strategy: '',
-            cache_path: ''
+            cache_path: '',
+            volumeReadOnly
         };
         let podTemplate;
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const AFFINITY_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
 const AFFINITY_PREFERRED_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
     'preferredDuringSchedulingIgnoredDuringExecution';
 const PREFERRED_WEIGHT = 100;
-const CACHE_STRATEGY = 'disk';
+const DISK_CACHE_STRATEGY = 'disk';
 
 /**
  * Parses nodeSelector config and update intended nodeSelector in tolerations
@@ -316,7 +316,7 @@ class K8sVMExecutor extends Executor {
         };
         let podTemplate;
 
-        if (this.cache_path && this.cache_strategy === CACHE_STRATEGY) {
+        if (this.cache_path && this.cache_strategy === DISK_CACHE_STRATEGY) {
             podSpec.cache_strategy = this.cache_strategy;
             podSpec.cache_path = this.cache_path;
             if (this.prefix) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -404,7 +404,7 @@ describe('index', () => {
             };
 
             const returnMessage = 'Failed to delete pod: '
-                  + `${JSON.stringify(fakeStopErrorResponse.body)}`;
+                + `${JSON.stringify(fakeStopErrorResponse.body)}`;
 
             requestRetryMock.yieldsAsync(null, fakeStopErrorResponse, fakeStopErrorResponse.body);
 
@@ -423,6 +423,7 @@ describe('index', () => {
         let getConfig;
         let putConfig;
         let fakeStartConfig;
+        let fakeStartConfigWithCache;
 
         const fakeStartResponse = {
             statusCode: 201,
@@ -509,6 +510,12 @@ describe('index', () => {
                 apiUri: testApiUri
             };
 
+            fakeStartConfigWithCache = fakeStartConfig;
+
+            fakeStartConfigWithCache.jobId = 1;
+            fakeStartConfigWithCache.eventId = 2;
+            fakeStartConfigWithCache.pipeline = { id: 3, scmContext: 'test' };
+
             requestRetryMock.withArgs(sinon.match({ method: 'POST' })).yieldsAsync(
                 null, fakeStartResponse, fakeStartResponse.body);
             requestRetryMock.withArgs(sinon.match({ method: 'GET' })).yieldsAsync(
@@ -519,6 +526,13 @@ describe('index', () => {
 
         it('successfully calls start', () =>
             executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            })
+        );
+
+        it('successfully calls start with cache', () =>
+            executor.start(fakeStartConfigWithCache).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
                 assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
             })
@@ -813,7 +827,7 @@ describe('index', () => {
                 }
             };
             const returnMessage = 'Failed to get pod status:' +
-                        `${JSON.stringify(returnResponse.body, null, 2)}`;
+                `${JSON.stringify(returnResponse.body, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(
                 null, returnResponse, returnResponse.body);
@@ -835,7 +849,7 @@ describe('index', () => {
                 }
             };
             const returnMessage = 'Failed to create pod. Pod status is:' +
-                        `${JSON.stringify(returnResponse.body.status, null, 2)}`;
+                `${JSON.stringify(returnResponse.body.status, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(
                 null, returnResponse, returnResponse.body);
@@ -888,7 +902,7 @@ describe('index', () => {
                 }
             };
             const returnMessage = 'Failed to create pod. Pod status is:' +
-                        `${JSON.stringify(returnResponse.body.status, null, 2)}`;
+                `${JSON.stringify(returnResponse.body.status, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(
                 null, returnResponse, returnResponse.body);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -267,7 +267,11 @@ describe('index', () => {
                 }
             },
             prefix: 'beta_',
-            launchVersion: 'v1.2.3'
+            launchVersion: 'v1.2.3',
+            cache: {
+                strategy: 's3',
+                path: '/test'
+            }
         });
         assert.equal(executor.buildTimeout, 30);
         assert.equal(executor.maxBuildTimeout, 300);
@@ -285,6 +289,8 @@ describe('index', () => {
         assert.equal(executor.highMemory, 5);
         assert.equal(executor.lowMemory, 2);
         assert.equal(executor.microMemory, 1);
+        assert.equal(executor.cache_strategy, 's3');
+        assert.equal(executor.cache_path, '/test');
     });
 
     it('allow empty options', () => {
@@ -531,12 +537,21 @@ describe('index', () => {
             })
         );
 
-        it('successfully calls start with cache', () =>
-            executor.start(fakeStartConfigWithCache).then(() => {
-                assert.calledWith(requestRetryMock.firstCall, postConfig);
-                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-            })
-        );
+        it('successfully calls start with cache', () => {
+            const options = _.assign({}, executorOptions, {
+                cache: {
+                    strategy: 'disk',
+                    path: '/test'
+                }
+            });
+
+            executor = new Executor(options);
+            executor.start(fakeStartConfigWithCache)
+                .then(() => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                });
+        });
 
         it('successfully calls start and update hostname', () => {
             const dateNow = Date.now();


### PR DESCRIPTION
## Context

In order to support build cache to disk strategy, kubernetes pods should be mounted with cache directory volumes, so builds can directly write to their respective cache directories

## Objective

When cache strategy is disk, k8s build pods are created with their respective cache directory volumes that are mounted and available to the build.

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
