### PR TITLE
fix(1830): get pipeline id

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,17 +241,17 @@ class K8sVMExecutor extends Executor {
      * @param  {Object}   config                        A configuration object
      * @param  {Object}   [config.annotations]          Set of key value pairs
      * @param  {Integer}  config.buildId                ID for the build
-     * @param  {Integer}  config.meta.build.pipeline.id pipelineId for the build
+     * @param  {Integer}  config.pipeline.id            pipelineId for the build
      * @param  {Integer}  config.jobId                  jobId for the build
      * @param  {Integer}  config.eventId                eventId for the build
      * @param  {String}   config.container              Container for the build to run in
      * @param  {String}   config.token                  JWT for the Build
+     * @param  {String}   config.jobName                jobName for the build
      * @return {Promise}
      */
     _start(config) {
-        const { buildId, jobId, eventId, container, token } = config;
-        const pipelineId = hoek.reach(config, 'meta.build.pipelineId', { default: '' });
-        const jobName = hoek.reach(config, 'meta.build.jobName', { default: '' });
+        const { buildId, jobId, eventId, container, token, jobName } = config;
+        const pipelineId = hoek.reach(config, 'pipeline.id', { default: '' });
         const annotations = this.parseAnnotations(
             hoek.reach(config, 'annotations', { default: {} }));
         const cpuConfig = annotations[CPU_RESOURCE];

--- a/index.js
+++ b/index.js
@@ -250,8 +250,9 @@ class K8sVMExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
-        const { buildId, jobId, eventId, container, token, jobName } = config;
+        const { buildId, jobId, eventId, container, token } = config;
         const pipelineId = hoek.reach(config, 'pipeline.id', { default: '' });
+        const jobName = hoek.reach(config, 'jobName', { default: '' });
         const annotations = this.parseAnnotations(
             hoek.reach(config, 'annotations', { default: {} }));
         const cpuConfig = annotations[CPU_RESOURCE];


### PR DESCRIPTION
## Context

pipelineid is not available under config.meta instead under config.pipeline.id

## Objective

Get pipelineid from config.pipeline.id

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
