### PR TITLE
fix(1830): add md5check, compress, maxsize capabilities to pod template

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -51,7 +51,10 @@ spec:
          "--build_timeout", "{{build_timeout}}",
          "--launcher_version", "{{launcher_version}}",
          "--cache_strategy", "{{cache_strategy}}",
-         "--cache_path", "{{cache_path}}"
+         "--cache_path", "{{cache_path}}",
+         "--cache_compress", "{{cache_compress}}",
+         "--cache_md5check", "{{cache_md5check}}",
+         "--cache_max_size_mb", "{{cache_max_size_mb}}"
           ]
     env:
     - name: PUSHGATEWAY_URL

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -51,7 +51,10 @@ spec:
          "--build_timeout", "{{build_timeout}}",
          "--launcher_version", "{{launcher_version}}",
          "--cache_strategy", "{{cache_strategy}}",
-         "--cache_path", "{{cache_path}}"
+         "--cache_path", "{{cache_path}}",
+         "--cache_compress", "{{cache_compress}}",
+         "--cache_md5check", "{{cache_md5check}}",
+         "--cache_max_size_mb", "{{cache_max_size_mb}}"
           ]
     env:
     - name: PUSHGATEWAY_URL

--- a/index.js
+++ b/index.js
@@ -196,8 +196,12 @@ class K8sVMExecutor extends Executor {
 
         this.nodeSelectors = hoek.reach(options, 'kubernetes.nodeSelectors');
         this.preferredNodeSelectors = hoek.reach(options, 'kubernetes.preferredNodeSelectors');
-        this.cache_strategy = hoek.reach(options, 'ecosystem.cache.strategy', { default: 's3' });
-        this.cache_path = hoek.reach(options, 'ecosystem.cache.path', { default: '/' });
+        this.cacheStrategy = hoek.reach(options, 'ecosystem.cache.strategy', { default: 's3' });
+        this.cachePath = hoek.reach(options, 'ecosystem.cache.path', { default: '/' });
+        this.cacheCompress = hoek.reach(options, 'ecosystem.cache.compress', { default: 'false' });
+        this.cacheMd5Check = hoek.reach(options, 'ecosystem.cache.md5check', { default: 'false' });
+        this.cacheMaxSizeInMB = hoek.reach(options,
+            'ecosystem.cache.max_size_mb', { default: 0 });
     }
 
     /**
@@ -316,8 +320,11 @@ class K8sVMExecutor extends Executor {
             launcher_image: `${this.launchImage}:${this.launchVersion}`,
             launcher_version: this.launchVersion,
             base_image: this.baseImage,
-            cache_strategy: this.cache_strategy,
-            cache_path: this.cache_path,
+            cache_strategy: this.cacheStrategy,
+            cache_path: this.cachePath,
+            cache_compress: this.cacheCompress,
+            cache_md5check: this.cacheMd5Check,
+            cache_max_size_mb: this.cacheMaxSizeInMB,
             volumeReadOnly
         };
         let podTemplate;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -271,7 +271,10 @@ describe('index', () => {
             ecosystem: {
                 cache: {
                     strategy: 's3',
-                    path: '/test'
+                    path: '/test',
+                    compress: 'true',
+                    md5check: 'true',
+                    max_size_mb: 2048
                 }
             }
         });
@@ -291,8 +294,11 @@ describe('index', () => {
         assert.equal(executor.highMemory, 5);
         assert.equal(executor.lowMemory, 2);
         assert.equal(executor.microMemory, 1);
-        assert.equal(executor.cache_strategy, 's3');
-        assert.equal(executor.cache_path, '/test');
+        assert.equal(executor.cacheStrategy, 's3');
+        assert.equal(executor.cachePath, '/test');
+        assert.equal(executor.cacheCompress, 'true');
+        assert.equal(executor.cacheMd5Check, 'true');
+        assert.equal(executor.cacheMaxSizeInMB, '2048');
     });
 
     it('allow empty options', () => {


### PR DESCRIPTION
## Objective

add md5 check, compress, and cache max size 

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
