### PR TITLE
fix(1830): [ DNM ] update cache path to not conflict with /opt/sd

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -70,12 +70,12 @@ spec:
       name: sd-workspaces
     - mountPath: /opt/sd
       name: sdlauncher
-    - mountPath: /opt/sd/cache/pipeline
+    - mountPath: /sdpipelinecache
       name: sd-pipeline-cache
       readOnly: {{volumeReadOnly}}
-    - mountPath: /opt/sd/cache/job
+    - mountPath: /sdjobcache
       name: sd-job-cache
-    - mountPath: /opt/sd/cache/event
+    - mountPath: /sdeventcache
       name: sd-event-cache
   initContainers:
   - name: launcher


### PR DESCRIPTION
## Context

Cache path /opt/sd/cache/ is conflicting with /opt/sd path and sd commands are failing.

## Objective

Move cache path outside of /opt/sd

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
