### PR TITLE
fix(1887): fix build cache folder permissions

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -80,10 +80,16 @@ spec:
   initContainers:
   - name: launcher
     image: {{launcher_image}}
-    command: ['/bin/sh', '-c', 'if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'chmod -R 777 /opt/sdcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher
+    - mountPath: /opt/sdcache/pipeline
+      name: sd-pipeline-cache
+    - mountPath: /opt/sdcache/job
+      name: sd-job-cache
+    - mountPath: /opt/sdcache/event
+      name: sd-event-cache
   volumes:
     - name: hyper-socket
       hostPath:

--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -80,15 +80,15 @@ spec:
   initContainers:
   - name: launcher
     image: {{launcher_image}}
-    command: ['/bin/sh', '-c', 'chmod -R 777 /opt/sdcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'chmod -R 777 /opt/sdcachepipeline && chmod -R 777 /opt/sdcachejob && chmod -R 777 /opt/sdcacheevent && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
     volumeMounts:
     - mountPath: /opt/launcher
       name: sdlauncher
-    - mountPath: /opt/sdcache/pipeline
+    - mountPath: /opt/sdcachepipeline
       name: sd-pipeline-cache
-    - mountPath: /opt/sdcache/job
+    - mountPath: /opt/sdcachejob
       name: sd-job-cache
-    - mountPath: /opt/sdcache/event
+    - mountPath: /opt/sdcacheevent
       name: sd-event-cache
   volumes:
     - name: hyper-socket


### PR DESCRIPTION
## Context

When a build is running as a non-root user, build cache fails with error "permission denied in set cache" when using disk-based strategy, due to permission issue on created folders.

## Objective

This PR will give permissions to build related folders
 
## References

[1887](https://github.com/screwdriver-cd/screwdriver/issues/1887)
[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
