### PR TITLE
fix(1905): PR builds to get cache at job level cache scope

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -75,6 +75,7 @@ spec:
       readOnly: {{volumeReadOnly}}
     - mountPath: /opt/sd/cache/job
       name: sd-job-cache
+      readOnly: {{volumeReadOnly}}
     - mountPath: /opt/sd/cache/event
       name: sd-event-cache
   initContainers:

--- a/index.js
+++ b/index.js
@@ -281,7 +281,6 @@ class K8sVMExecutor extends Executor {
             jobId = hoek.reach(decodedToken.payload,
                 'prParentJobId', { default: jobId });
         }
-        //
 
         let cpu = (cpuConfig in cpuValues) ? cpuValues[cpuConfig] : cpuValues.LOW;
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const requestretry = require('requestretry');
 const tinytim = require('tinytim');
 const yaml = require('js-yaml');
 const _ = require('lodash');
+const jwt = require('jsonwebtoken');
 
 const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
 const MAX_BUILD_TIMEOUT = 120; // 120 minutes
@@ -27,7 +28,6 @@ const AFFINITY_PREFERRED_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
     'preferredDuringSchedulingIgnoredDuringExecution';
 const PREFERRED_WEIGHT = 100;
 const DISK_CACHE_STRATEGY = 'disk';
-const jwt = require('jsonwebtoken');
 
 /**
  * Parses nodeSelector config and update intended nodeSelector in tolerations
@@ -269,7 +269,7 @@ class K8sVMExecutor extends Executor {
             MICRO: this.microCpu
         };
 
-        // PRs - set pipeline, job cache volume readonly and job cache dir to refer parent job
+        // PRs - set pipeline, job cache volume readonly and job cache dir to parent job cache dir
         const regex = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
         const matched = regex.exec(jobName);
         let volumeReadOnly = false;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "requestretry": "^4.0.0",
         "screwdriver-data-schema": "^19.1.1",
         "screwdriver-executor-base": "^7.0.0",
-        "tinytim": "^0.1.1"
+        "tinytim": "^0.1.1",
+        "jsonwebtoken": "^7.1.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "chai": "^3.5.0",
         "eslint": "^4.19.1",
         "eslint-config-screwdriver": "^3.0.1",
-        "jenkins-mocha": "^7.0.0",
+        "jenkins-mocha": "^8.0.0",
         "mockery": "^2.0.0",
         "rewire": "^3.0.2",
         "sinon": "^5.0.10"
@@ -60,6 +60,6 @@
         "screwdriver-data-schema": "^19.1.1",
         "screwdriver-executor-base": "^7.0.0",
         "tinytim": "^0.1.1",
-        "jsonwebtoken": "^7.1.6"
+        "jsonwebtoken": "^8.5.1"
     }
 }


### PR DESCRIPTION
## Context

PR builds get cache fails for job level cache scope.

## Objective

This PR will fix get cache issue at job level scope, regex pattern to identify PR and mount read-only job cache volume.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1905

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
