### PR TITLE
fix: typo cache-max_go_threads

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -55,7 +55,7 @@ spec:
          "--cache_compress", "{{cache_compress}}",
          "--cache_md5check", "{{cache_md5check}}",
          "--cache_max_size_mb", "{{cache_max_size_mb}}",
-         "--cache-max_go_threads", "{{cache_max_go_threads}}"
+         "--cache_max_go_threads", "{{cache_max_go_threads}}"
           ]
     env:
     - name: SD_PUSHGATEWAY_URL

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -55,7 +55,7 @@ spec:
          "--cache_compress", "{{cache_compress}}",
          "--cache_md5check", "{{cache_md5check}}",
          "--cache_max_size_mb", "{{cache_max_size_mb}}",
-         "--cache-max_go_threads", "{{cache_max_go_threads}}"
+         "--cache_max_go_threads", "{{cache_max_go_threads}}"
           ]
     env:
     - name: SD_PUSHGATEWAY_URL

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ class K8sVMExecutor extends Executor {
             cache_compress: this.cacheCompress,
             cache_md5check: this.cacheMd5Check,
             cache_max_size_mb: this.cacheMaxSizeInMB,
-            max_go_threads: this.cacheMaxGoThreads,
+            cache_max_go_threads: this.cacheMaxGoThreads,
             volumeReadOnly
         };
         let podTemplate;


### PR DESCRIPTION
## Context

Error: tim: 'cache_max_go_threads' not found in {{cache_max_go_threads}}

## Objective

 in pod creation definition, change var name max_go_threads to cache_max_go_threads

## References

[executor-k8s-vm-PR#75](https://github.com/screwdriver-cd/executor-k8s-vm/pull/75)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
