### PR TITLE
feat: add terminationGracePeriodSeconds annotation

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -20,6 +20,7 @@ spec:
               values:
               - screwdriver-vm
   restartPolicy: Never
+  terminationGracePeriodSeconds: {{termination_grace_period_seconds}}
   containers:
   - name: vm-launcher
     image: {{base_image}}

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -20,6 +20,7 @@ spec:
               values:
               - screwdriver-vm
   restartPolicy: Never
+  terminationGracePeriodSeconds: {{termination_grace_period_seconds}}
   containers:
   - name: vm-launcher
     image: {{base_image}}

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ class K8sVMExecutor extends Executor {
         this.baseImage = this.kubernetes.baseImage;
         this.buildTimeout = this.kubernetes.buildTimeout || DEFAULT_BUILD_TIMEOUT;
         this.maxBuildTimeout = this.kubernetes.maxBuildTimeout || MAX_BUILD_TIMEOUT;
-        this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 60;
+        this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 30;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
         this.retryDelay = this.requestretryOptions.retryDelay || DEFAULT_RETRYDELAY;

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const AFFINITY_PREFERRED_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
     'preferredDuringSchedulingIgnoredDuringExecution';
 const PREFERRED_WEIGHT = 100;
 const DISK_CACHE_STRATEGY = 'disk';
+const TERMINATION_GRACE_PERIOD_SECONDS = 'terminationGracePeriodSeconds';
 
 /**
  * Parses nodeSelector config and update intended nodeSelector in tolerations
@@ -133,6 +134,7 @@ class K8sVMExecutor extends Executor {
      * @param  {String} [options.kubernetes.resources.disk.speed]       Value for disk speed label (e.g.: screwdriver.cd/diskSpeed)
      * @param  {Number} [options.kubernetes.jobsNamespace=default]      Pods namespace for Screwdriver Jobs
      * @param  {Object} [options.kubernetes.nodeSelectors]              Object representing node label-value pairs
+     * @param  {String} [options.kubernetes.terminationGracePeriodSeconds] TerminationGracePeriodSeconds setting for k8s pods
      * @param  {String} [options.launchVersion=stable]                  Launcher container version to use
      * @param  {String} [options.prefix='']                             Prefix for job name
      * @param  {String} [options.fusebox]                               Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
@@ -168,6 +170,7 @@ class K8sVMExecutor extends Executor {
         this.baseImage = this.kubernetes.baseImage;
         this.buildTimeout = this.kubernetes.buildTimeout || DEFAULT_BUILD_TIMEOUT;
         this.maxBuildTimeout = this.kubernetes.maxBuildTimeout || MAX_BUILD_TIMEOUT;
+        this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 60;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
         this.retryDelay = this.requestretryOptions.retryDelay || DEFAULT_RETRYDELAY;
@@ -320,6 +323,12 @@ class K8sVMExecutor extends Executor {
             ? Math.min(annotations[ANNOTATION_BUILD_TIMEOUT], this.maxBuildTimeout)
             : this.buildTimeout;
 
+        const terminationGracePeriod = annotations[TERMINATION_GRACE_PERIOD_SECONDS]
+            ? Math.max(
+                annotations[TERMINATION_GRACE_PERIOD_SECONDS], this.terminationGracePeriodSeconds
+            )
+            : this.terminationGracePeriodSeconds;
+
         const podSpec = {
             cpu,
             memory,
@@ -337,6 +346,7 @@ class K8sVMExecutor extends Executor {
             pushgateway_url: hoek.reach(this.ecosystem, 'pushgatewayUrl', { default: '' }),
             token,
             launcher_image: `${this.launchImage}:${this.launchVersion}`,
+            termination_grace_period_seconds: terminationGracePeriod,
             launcher_version: this.launchVersion,
             base_image: this.baseImage,
             cache_strategy: this.cacheStrategy,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -558,12 +558,11 @@ describe('index', () => {
             })
         );
 
-        it.skip('successfully calls start with cache', () => {
+        it('successfully calls start with cache', () => {
             const options = _.assign({}, executorOptions, {
                 ecosystem: {
                     api: testApiUri,
                     store: testStoreUri,
-                    ui: 'test',
                     cache: {
                         strategy: 'disk',
                         path: '/test'
@@ -572,6 +571,8 @@ describe('index', () => {
             });
 
             executor = new Executor(options);
+            getConfig.retryStrategy = executor.podRetryStrategy;
+
             executor.start(fakeStartConfigWithCache)
                 .then(() => {
                     assert.calledWith(requestRetryMock.firstCall, postConfig);


### PR DESCRIPTION
## Context

Currently if a build is aborted the teardown steps don't run and hence generated artifacts are not available in this case, so we need to increase the grace period before pod termination to run the artifact saving steps

## Objective

This PR adds provision to increase pod timeout by using annotations

## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
