### PR TITLE
feat: add terminationgraceperiod env var

### DIFF
--- a/config/pod.cache2disk.yaml.tim
+++ b/config/pod.cache2disk.yaml.tim
@@ -61,6 +61,8 @@ spec:
     env:
     - name: SD_PUSHGATEWAY_URL
       value: "{{pushgateway_url}}"
+    - name: SD_TERMINATION_GRACE_PERIOD_SECONDS
+      value: {{termination_grace_period_seconds}}
     - name: NODE_ID
       valueFrom:
         fieldRef:

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -61,6 +61,8 @@ spec:
     env:
     - name: SD_PUSHGATEWAY_URL
       value: "{{pushgateway_url}}"
+    - name: SD_TERMINATION_GRACE_PERIOD_SECONDS
+      value: {{termination_grace_period_seconds}}
     - name: NODE_ID
       valueFrom:
         fieldRef:


### PR DESCRIPTION
## Context

Currently if a build is aborted the teardown steps don't run and hence generated artifacts are not available in this case, so we need to increase the grace period before pod termination to run the artifact saving steps

## Objective

This PR adds pod timeout configuration to env var
## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
